### PR TITLE
Initialize agent shields

### DIFF
--- a/mettagrid/mettagrid.pyx
+++ b/mettagrid/mettagrid.pyx
@@ -39,7 +39,6 @@ cdef class MettaGrid(GridEnv):
             obs_encoder = MettaCompactObservationEncoder()
 
         actions = []
-        print(f"shield enabled: {cfg.actions.shield.enabled}")
         if cfg.actions.noop.enabled:
             actions.append(Noop(cfg.actions.noop))
         if cfg.actions.move.enabled:

--- a/mettagrid/mettagrid.pyx
+++ b/mettagrid/mettagrid.pyx
@@ -39,6 +39,7 @@ cdef class MettaGrid(GridEnv):
             obs_encoder = MettaCompactObservationEncoder()
 
         actions = []
+        print(f"shield enabled: {cfg.actions.shield.enabled}")
         if cfg.actions.noop.enabled:
             actions.append(Noop(cfg.actions.noop))
         if cfg.actions.move.enabled:

--- a/mettagrid/objects.pxd
+++ b/mettagrid/objects.pxd
@@ -83,6 +83,7 @@ cdef cppclass Agent(MettaObject):
         this.inventory.resize(InventoryItem.InventoryCount)
         this.max_items = cfg[b"max_inventory"]
         this.energy_reward = float(cfg[b"energy_reward"]) / 1000.0
+        this.shield = False
 
     inline void update_inventory(InventoryItem item, short amount):
         this.inventory[<InventoryItem>item] += amount


### PR DESCRIPTION
Previously we weren't initializing, so they'd be set to whatever happened to be stored in memory.

Tested by re-running a training run where shields had been disabled, but `shield.ticks` had still be showing up in stats. Confirmed shield ticks no longer showed up.

https://app.asana.com/0/1209096222434381/1209157050289498/f