### PR TITLE
Configurable converters

### DIFF
--- a/mettagrid/actions/use.pyx
+++ b/mettagrid/actions/use.pyx
@@ -6,7 +6,7 @@ from omegaconf import OmegaConf
 from mettagrid.grid_object cimport GridLocation, GridObjectId, Orientation, GridObject
 from mettagrid.action cimport ActionHandler, ActionArg
 from mettagrid.objects cimport MettaObject, ObjectType, Usable, Altar, Agent, Events, GridLayer
-from mettagrid.objects cimport Generator, Converter, InventoryItem, ObjectTypeNames, InventoryItemNames
+from mettagrid.objects cimport Generator, Converter, ConverterRecipe, InventoryItem, ObjectTypeNames, InventoryItemNames
 from mettagrid.actions.actions cimport MettaActionHandler
 
 cdef class Use(MettaActionHandler):
@@ -55,17 +55,19 @@ cdef class Use(MettaActionHandler):
             self.env._stats.game_incr("r1.harvested")
 
         cdef Converter *converter
+        cdef ConverterRecipe recipe
         cdef unsigned int energy_gain = 0
         if target._type_id == ObjectType.ConverterT:
             converter = <Converter*>target
-            actor.update_inventory(converter.input_resource, -1)
-            self.env._stats.agent_incr(actor_id, InventoryItemNames[converter.input_resource] + ".used")
+            recipe = converter.recipies[0]
+            actor.update_energy(recipe.delta_energy, &self.env._rewards[actor_id])
+            for i in range(InventoryItem.InventoryCount):
+                if recipe.delta_resources[i] > 0:
+                    self.env._stats.agent_incr(actor_id, InventoryItemNames[i] + ".gained")
+                elif recipe.delta_resources[i] < 0:
+                    self.env._stats.agent_incr(actor_id, InventoryItemNames[i] + ".used")
+                actor.update_inventory(i, recipe.delta_resources[i])
 
-            actor.update_inventory(converter.output_resource, 1)
-            self.env._stats.agent_incr(actor_id, InventoryItemNames[converter.output_resource] + ".gained")
-
-            energy_gain = actor.update_energy(converter.output_energy, &self.env._rewards[actor_id])
-
-            self.env._stats.agent_add(actor_id, "energy.gained", energy_gain)
+            # self.env._stats.agent_add(actor_id, "energy.gained", energy_gain)
 
         return True

--- a/mettagrid/actions/use.pyx
+++ b/mettagrid/actions/use.pyx
@@ -59,7 +59,7 @@ cdef class Use(MettaActionHandler):
         cdef unsigned int energy_gain = 0
         if target._type_id == ObjectType.ConverterT:
             converter = <Converter*>target
-            recipe = converter.recipies[0]
+            recipe = converter.recipes[0]
             actor.update_energy(recipe.delta_energy, &self.env._rewards[actor_id])
             for i in range(InventoryItem.InventoryCount):
                 if recipe.delta_resources[i] > 0:

--- a/mettagrid/mettagrid.pyx
+++ b/mettagrid/mettagrid.pyx
@@ -71,9 +71,9 @@ cdef class MettaGrid(GridEnv):
             track_last_action=env_cfg.track_last_action
         )
 
-        # create converter recipies
-        cdef vector[ConverterRecipe] recipies;
-        recipies.push_back(ConverterRecipe())
+        # create converter recipes
+        cdef vector[ConverterRecipe] recipes;
+        recipes.push_back(ConverterRecipe())
 
         cdef Agent *agent
         for r in range(map.shape[0]):
@@ -86,7 +86,7 @@ cdef class MettaGrid(GridEnv):
                     self._grid.add_object(new Generator(r, c, cfg.objects.generator))
                     self._stats.game_incr("objects.generator")
                 elif map[r,c] == "c":
-                    self._grid.add_object(new Converter(r, c, cfg.objects.converter, recipies))
+                    self._grid.add_object(new Converter(r, c, cfg.objects.converter, recipes))
                     self._stats.game_incr("objects.converter")
                 elif map[r,c] == "a":
                     self._grid.add_object(new Altar(r, c, cfg.objects.altar))

--- a/mettagrid/mettagrid.pyx
+++ b/mettagrid/mettagrid.pyx
@@ -1,6 +1,6 @@
 
 from libc.stdio cimport printf
-
+from libcpp.vector cimport vector
 
 import numpy as np
 cimport numpy as cnp
@@ -12,7 +12,7 @@ from mettagrid.grid_env cimport GridEnv
 from mettagrid.grid_object cimport GridObject
 from mettagrid.observation_encoder cimport ObsType
 
-from mettagrid.objects cimport ObjectLayers, Agent, ResetHandler, Wall, Generator, Converter, Altar
+from mettagrid.objects cimport ObjectLayers, Agent, ResetHandler, Wall, Generator, Converter, ConverterRecipe, Altar
 from mettagrid.observation_encoder cimport MettaObservationEncoder, MettaCompactObservationEncoder
 from mettagrid.actions.move import Move
 from mettagrid.actions.rotate import Rotate
@@ -71,9 +71,14 @@ cdef class MettaGrid(GridEnv):
             track_last_action=env_cfg.track_last_action
         )
 
+        # create converter recipies
+        cdef vector[ConverterRecipe] recipies;
+        recipies.push_back(ConverterRecipe())
+
         cdef Agent *agent
         for r in range(map.shape[0]):
             for c in range(map.shape[1]):
+                # oh -- we read off the map here!
                 if map[r,c] == "W":
                     self._grid.add_object(new Wall(r, c, cfg.objects.wall))
                     self._stats.game_incr("objects.wall")
@@ -81,7 +86,7 @@ cdef class MettaGrid(GridEnv):
                     self._grid.add_object(new Generator(r, c, cfg.objects.generator))
                     self._stats.game_incr("objects.generator")
                 elif map[r,c] == "c":
-                    self._grid.add_object(new Converter(r, c, cfg.objects.converter))
+                    self._grid.add_object(new Converter(r, c, cfg.objects.converter, recipies))
                     self._stats.game_incr("objects.converter")
                 elif map[r,c] == "a":
                     self._grid.add_object(new Altar(r, c, cfg.objects.altar))

--- a/mettagrid/mettagrid.pyx
+++ b/mettagrid/mettagrid.pyx
@@ -78,7 +78,6 @@ cdef class MettaGrid(GridEnv):
         cdef Agent *agent
         for r in range(map.shape[0]):
             for c in range(map.shape[1]):
-                # oh -- we read off the map here!
                 if map[r,c] == "W":
                     self._grid.add_object(new Wall(r, c, cfg.objects.wall))
                     self._stats.game_incr("objects.wall")

--- a/mettagrid/objects.pxd
+++ b/mettagrid/objects.pxd
@@ -154,38 +154,50 @@ cdef cppclass Generator(Usable):
         obs[2] = this.r1
         obs[3] = this.ready and this.r1 > 0
 
-
     @staticmethod
     inline vector[string] feature_names():
         return ["generator", "generator:hp", "generator:r1", "generator:ready"]
 
-cdef cppclass Converter(Usable):
-    InventoryItem input_resource
-    InventoryItem output_resource
-    short output_energy
+cdef cppclass ConverterRecipe:
+    # positive for gain, negative for loss
+    vector[char] delta_resources
+    short delta_energy
+    short reward
 
-    inline Converter(GridCoord r, GridCoord c, ObjectConfig cfg):
+    inline ConverterRecipe():
+        this.delta_resources.resize(InventoryItem.InventoryCount)
+        this.delta_resources[InventoryItem.r1] = -1
+        this.delta_resources[InventoryItem.r2] = 1
+        this.delta_energy = 100
+        this.reward = 0
+
+cdef cppclass Converter(Usable):
+    vector[ConverterRecipe] recipies
+
+    inline Converter(GridCoord r, GridCoord c, ObjectConfig cfg, vector[ConverterRecipe] recipies):
         GridObject.init(ObjectType.ConverterT, GridLocation(r, c, GridLayer.Object_Layer))
         MettaObject.init_mo(cfg)
         Usable.init_usable(cfg)
-        this.input_resource = InventoryItem.r1
-        this.output_resource = InventoryItem.r2
-        this.output_energy = cfg[b"energy_output.r1"]
+        # This is copying -- maybe we should just pass in a pointer?
+        this.recipies = recipies
 
     inline bint usable(const Agent *actor):
-        return Usable.usable(actor) and actor.inventory[this.input_resource] > 0
+        cdef ConverterRecipe recipe = this.recipies[0]
+        if -recipe.delta_energy > actor.energy:
+            return False
+        for i in range(InventoryItem.InventoryCount):
+            if -recipe.delta_resources[i] > actor.inventory[i]:
+                return False
+        return Usable.usable(actor)
 
     inline obs(ObsType[:] obs):
         obs[0] = 1
         obs[1] = hp
-        obs[2] = input_resource
-        obs[3] = output_resource
-        obs[4] = output_energy
         obs[5] = ready
 
     @staticmethod
     inline vector[string] feature_names():
-        return ["converter", "converter:hp", "converter:input_resource", "converter:output_resource", "converter:output_energy", "converter:ready"]
+        return ["converter", "converter:hp", "converter:ready"]
 
 cdef cppclass Altar(Usable):
     inline Altar(GridCoord r, GridCoord c, ObjectConfig cfg):

--- a/mettagrid/objects.pxd
+++ b/mettagrid/objects.pxd
@@ -193,11 +193,14 @@ cdef cppclass Converter(Usable):
     inline obs(ObsType[:] obs):
         obs[0] = 1
         obs[1] = hp
-        obs[5] = ready
+        obs[2] = ready
+        obs[3] = 0
+        obs[4] = 0
+        obs[5] = 0
 
     @staticmethod
     inline vector[string] feature_names():
-        return ["converter", "converter:hp", "converter:ready"]
+        return ["converter", "converter:hp", "converter:ready", "converter:na1", "converter:na2", "converter:na3"]
 
 cdef cppclass Altar(Usable):
     inline Altar(GridCoord r, GridCoord c, ObjectConfig cfg):

--- a/mettagrid/objects.pxd
+++ b/mettagrid/objects.pxd
@@ -103,6 +103,7 @@ cdef cppclass Agent(MettaObject):
         return amount
 
     inline void obs(ObsType[:] obs):
+        # #ObservationDefinition
         obs[0] = 1
         obs[1] = this.hp
         obs[2] = this.frozen
@@ -129,6 +130,7 @@ cdef cppclass Wall(MettaObject):
         MettaObject.init_mo(cfg)
 
     inline void obs(ObsType[:] obs):
+        # #ObservationDefinition
         obs[0] = 1
         obs[1] = hp
 
@@ -149,6 +151,7 @@ cdef cppclass Generator(Usable):
         return Usable.usable(actor) and this.r1 > 0
 
     inline void obs(ObsType[:] obs):
+        # #ObservationDefinition
         obs[0] = 1
         obs[1] = this.hp
         obs[2] = this.r1
@@ -191,16 +194,14 @@ cdef cppclass Converter(Usable):
         return Usable.usable(actor)
 
     inline obs(ObsType[:] obs):
+        # #ObservationDefinition
         obs[0] = 1
         obs[1] = hp
         obs[2] = ready
-        obs[3] = 0
-        obs[4] = 0
-        obs[5] = 0
 
     @staticmethod
     inline vector[string] feature_names():
-        return ["converter", "converter:hp", "converter:ready", "converter:na1", "converter:na2", "converter:na3"]
+        return ["converter", "converter:hp", "converter:ready"]
 
 cdef cppclass Altar(Usable):
     inline Altar(GridCoord r, GridCoord c, ObjectConfig cfg):
@@ -209,6 +210,7 @@ cdef cppclass Altar(Usable):
         Usable.init_usable(cfg)
 
     inline void obs(ObsType[:] obs):
+        # #ObservationDefinition
         obs[0] = 1
         obs[1] = hp
         obs[2] = ready

--- a/mettagrid/objects.pxd
+++ b/mettagrid/objects.pxd
@@ -181,7 +181,6 @@ cdef cppclass Converter(Usable):
         GridObject.init(ObjectType.ConverterT, GridLocation(r, c, GridLayer.Object_Layer))
         MettaObject.init_mo(cfg)
         Usable.init_usable(cfg)
-        # This is copying -- maybe we should just pass in a pointer?
         this.recipies = recipies
 
     inline bint usable(const Agent *actor):

--- a/mettagrid/objects.pxd
+++ b/mettagrid/objects.pxd
@@ -175,16 +175,16 @@ cdef cppclass ConverterRecipe:
         this.reward = 0
 
 cdef cppclass Converter(Usable):
-    vector[ConverterRecipe] recipies
+    vector[ConverterRecipe] recipes
 
-    inline Converter(GridCoord r, GridCoord c, ObjectConfig cfg, vector[ConverterRecipe] recipies):
+    inline Converter(GridCoord r, GridCoord c, ObjectConfig cfg, vector[ConverterRecipe] recipes):
         GridObject.init(ObjectType.ConverterT, GridLocation(r, c, GridLayer.Object_Layer))
         MettaObject.init_mo(cfg)
         Usable.init_usable(cfg)
-        this.recipies = recipies
+        this.recipes = recipes
 
     inline bint usable(const Agent *actor):
-        cdef ConverterRecipe recipe = this.recipies[0]
+        cdef ConverterRecipe recipe = this.recipes[0]
         if -recipe.delta_energy > actor.energy:
             return False
         for i in range(InventoryItem.InventoryCount):


### PR DESCRIPTION
This adds configurable converters. I've been sitting on the code for a while, but figured I'd make a draft while I think through pieces.

Right now there's a single, hard coded configuration that replaces existing converters. Heart altars should be able to be replaces with the same object, different recipe. Generators can almost be replaced, with the exception that generators can accumulate things you can pick up, and the current implementation of recipes doesn't offer that.

I'm not sure what to do about switching recipes, of recipe visibility. It seems reasonable to see the recipe that a converter is set to, and maybe have a way of seeing what that recipe does. I know how to encode the former, though the numeric nature of the variable will be misleading. I'm not sure what to do about giving info about what recipes do.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1209230969804461/1209257697502252) by [Unito](https://www.unito.io)
