### PR TITLE
Some renaming and make_odd

### DIFF
--- a/mettagrid/config/room/ascii.py
+++ b/mettagrid/config/room/ascii.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from mettagrid.config.room.room import Room, OBJECTS, GameObject
 
-class AsciiRoom(Room):
+class Asci(Room):
     def __init__(self, uri: str, border_width: int = 0, border_object: GameObject = OBJECTS.Wall):
         super().__init__(border_width=border_width, border_object=border_object)
         with open(uri, "r", encoding="utf-8") as f:

--- a/mettagrid/config/room/ascii.py
+++ b/mettagrid/config/room/ascii.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from mettagrid.config.room.room import Room, OBJECTS, GameObject
 
-class Asci(Room):
+class Ascii(Room):
     def __init__(self, uri: str, border_width: int = 0, border_object: GameObject = OBJECTS.Wall):
         super().__init__(border_width=border_width, border_object=border_object)
         with open(uri, "r", encoding="utf-8") as f:

--- a/mettagrid/config/room/cylinder.py
+++ b/mettagrid/config/room/cylinder.py
@@ -1,5 +1,4 @@
 from typing import Set, Tuple
-
 import numpy as np
 from omegaconf import DictConfig
 from mettagrid.config.room.room import OBJECTS, GameObject, Room

--- a/mettagrid/config/room/cylinder.py
+++ b/mettagrid/config/room/cylinder.py
@@ -2,11 +2,9 @@ from typing import Set, Tuple
 
 import numpy as np
 from omegaconf import DictConfig
-
 from mettagrid.config.room.room import OBJECTS, GameObject, Room
 
-
-class CylinderRoom(Room):
+class Cylinder(Room):
     def __init__(
         self,
         width: int,

--- a/mettagrid/config/room/cylinder.py
+++ b/mettagrid/config/room/cylinder.py
@@ -23,14 +23,13 @@ class Cylinder(Room):
 
         # Validate inputs
         assert 3 <= cylinder_params['length'], "Cylinder length must be at least 3"
-        assert cylinder_params['orientation'] in ['horizontal', 'vertical'], "Invalid orientation"
 
         # Initialize grid
         self._grid = np.full((self._height, self._width), OBJECTS.Empty.symbol, dtype=str)
         self._cylinder_positions = set()
 
     def _build(self) -> np.ndarray:
-        if self._cylinder_params['orientation'] == 'horizontal':
+        if self._cylinder_params['horizontal']:
             self.place_horizontal_cylinder()
         else:
             self.place_vertical_cylinder()
@@ -99,7 +98,7 @@ class Cylinder(Room):
 
     def _place_elements(self, valid_positions: Set[Tuple[int, int]]) -> None:
         """Place altar and converter in valid positions."""
-        if self._cylinder_params['orientation'] == 'horizontal':
+        if self._cylinder_params['horizontal']:
             top_positions = [(x, y) for x, y in valid_positions if y < self._height//2]
             left_positions = [pos for pos in top_positions if pos[0] < self._width//2]
             right_positions = [pos for pos in top_positions if pos[0] >= self._width//2]

--- a/mettagrid/config/room/maze.py
+++ b/mettagrid/config/room/maze.py
@@ -4,6 +4,10 @@ import numpy as np
 
 from mettagrid.config.room.room import OBJECTS, Room
 
+def make_odd(x):
+    if x % 2 == 0:
+        x += 1
+
 class Maze(Room):
     EMPTY, WALL = OBJECTS.Empty.symbol, OBJECTS.Wall.symbol
     START, END = OBJECTS.Agent.symbol, OBJECTS.Altar.symbol
@@ -20,9 +24,11 @@ class Maze(Room):
 
         # Validate inputs
         assert 0 <= self._branching <= 1, "Branching parameter must be between 0 and 1"
-        assert self._width % 2 == 1 and self._width >= 3, "Width must be odd and >= 3. Got {}".format(self._width)
-        assert self._height % 2 == 1 and self._height >= 3, "Height must be odd and >= 3. Got {}".format(self._height)
-        assert self._start_pos[0] % 2 == 1 and self._start_pos[1] % 2 == 1, "Start position must have odd coordinates"
+        make_odd(self._width)
+        make_odd(self._height)
+        make_odd(self._start_pos[0])
+        make_odd(self._start_pos[1])
+
         if self._end_pos:
             assert self._end_pos[0] % 2 == 1 and self._end_pos[1] % 2 == 1, "End position must have odd coordinates"
             assert 0 < self._end_pos[0] < self._width and 0 < self._end_pos[1] < self._height, "End position must be within maze bounds"


### PR DESCRIPTION
Note: planning on changing the maze algos anyway so this is not super important

For mazes, the requirement for odd dimensions comes from the fact that the algorithm creates corridors by moving in steps of 2 cells with walls in between. This ensures we always have proper walls between corridors and no adjacent corridors.

I changed it so that if we pass in even numbers it just converts them odd from within the maze class rather than in the yaml file. If we did a padding after the maze was constructed it would obstruct some of the maze. 

Do we want to be able to have even mazes? It would require some changes to the algorithm, which happy to make but just wondering if that's necessary

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1209230969804461/1209257796290569) by [Unito](https://www.unito.io)
