### PR TITLE
Add an attack nearest action

### DIFF
--- a/mettagrid/actions/attack.pxd
+++ b/mettagrid/actions/attack.pxd
@@ -1,4 +1,13 @@
 from mettagrid.actions.actions cimport MettaActionHandler
 
+from mettagrid.grid_object cimport GridLocation
+from mettagrid.objects cimport Agent
+
 cdef class Attack(MettaActionHandler):
     cdef int damage
+
+    cdef bint _handle_target(
+        self,
+        unsigned int actor_id,
+        Agent * actor,
+        GridLocation target_loc)

--- a/mettagrid/actions/attack.pyx
+++ b/mettagrid/actions/attack.pyx
@@ -36,8 +36,17 @@ cdef class Attack(MettaActionHandler):
             actor.location,
             <Orientation>actor.orientation,
             distance, offset)
+        
+        return self._handle_target(actor_id, actor, target_loc)
+
+    cdef bint _handle_target(
+        self,
+        unsigned int actor_id,
+        Agent * actor,
+        GridLocation target_loc):
 
         target_loc.layer = GridLayer.Agent_Layer
+        # Because we're looking on the agent layer, we can cast to Agent.
         cdef Agent * agent_target = <Agent *>self.env._grid.object_at(target_loc)
         cdef char stat_name[256]
 

--- a/mettagrid/actions/attack.pyx
+++ b/mettagrid/actions/attack.pyx
@@ -11,8 +11,8 @@ from mettagrid.objects cimport Generator, Converter, InventoryItem, ObjectTypeNa
 from mettagrid.actions.actions cimport MettaActionHandler
 
 cdef class Attack(MettaActionHandler):
-    def __init__(self, cfg: OmegaConf):
-        MettaActionHandler.__init__(self, cfg, "attack")
+    def __init__(self, cfg: OmegaConf, action_name: str="attack"):
+        MettaActionHandler.__init__(self, cfg, action_name)
         self._priority = 1
 
     cdef unsigned char max_arg(self):

--- a/mettagrid/actions/attack_nearest.pxd
+++ b/mettagrid/actions/attack_nearest.pxd
@@ -1,0 +1,4 @@
+from mettagrid.actions.attack cimport Attack
+
+cdef class AttackNearest(Attack):
+    pass

--- a/mettagrid/actions/attack_nearest.pyx
+++ b/mettagrid/actions/attack_nearest.pyx
@@ -13,7 +13,7 @@ from mettagrid.actions.attack cimport Attack
 
 cdef class AttackNearest(Attack):
     def __init__(self, cfg: OmegaConf):
-        MettaActionHandler.__init__(self, cfg, "attack_nearest")
+        Attack.__init__(self, cfg, "attack_nearest")
         self._priority = 1
 
     cdef unsigned char max_arg(self):

--- a/mettagrid/actions/attack_nearest.pyx
+++ b/mettagrid/actions/attack_nearest.pyx
@@ -1,0 +1,47 @@
+
+from libc.stdio cimport printf
+from libc.string cimport strcat, strcpy
+
+from omegaconf import OmegaConf
+
+from mettagrid.grid_object cimport GridLocation, GridObjectId, Orientation, GridObject
+from mettagrid.action cimport ActionHandler, ActionArg
+from mettagrid.objects cimport MettaObject, ObjectType, Usable, Altar, Agent, Events, GridLayer
+from mettagrid.objects cimport Generator, Converter, InventoryItem, ObjectTypeNames, InventoryItemNames
+from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.attack cimport Attack
+
+cdef class AttackNearest(Attack):
+    def __init__(self, cfg: OmegaConf):
+        MettaActionHandler.__init__(self, cfg, "attack_nearest")
+        self._priority = 1
+
+    cdef unsigned char max_arg(self):
+        return 0
+
+    cdef bint _handle_action(
+        self,
+        unsigned int actor_id,
+        Agent * actor,
+        ActionArg arg):
+
+        cdef int distance = 0
+        cdef int offset = 0
+        cdef GridLocation target_loc;
+        cdef Agent * agent_target;
+        
+        # xcxc see if this is efficient
+        for distance in range(1, 4):
+            # distance is clear, and attacking the middle before the edges seems right.
+            # preferring to attack left over right is arbitrary.
+            for offset in [0, -1, 1]:
+                target_loc = self.env._grid.relative_location(
+                    actor.location,
+                    <Orientation>actor.orientation,
+                    distance, offset)
+
+                target_loc.layer = GridLayer.Agent_Layer
+                agent_target = <Agent *>self.env._grid.object_at(target_loc)
+                if agent_target:
+                    return self._handle_target(actor_id, actor, target_loc)
+

--- a/mettagrid/actions/attack_nearest.pyx
+++ b/mettagrid/actions/attack_nearest.pyx
@@ -30,11 +30,12 @@ cdef class AttackNearest(Attack):
         cdef GridLocation target_loc;
         cdef Agent * agent_target;
         
-        # xcxc see if this is efficient
+        # Scan the space to find the nearest agent. Prefer the middle (offset 0) before the edges (offset -1, 1).
         for distance in range(1, 4):
-            # distance is clear, and attacking the middle before the edges seems right.
-            # preferring to attack left over right is arbitrary.
-            for offset in [0, -1, 1]:
+            for offset in range(3):
+                if offset == 2:
+                    # Sort of a mod 3 operation.
+                    offset = -1
                 target_loc = self.env._grid.relative_location(
                     actor.location,
                     <Orientation>actor.orientation,

--- a/mettagrid/actions/attack_nearest.pyx
+++ b/mettagrid/actions/attack_nearest.pyx
@@ -14,7 +14,6 @@ from mettagrid.actions.attack cimport Attack
 cdef class AttackNearest(Attack):
     def __init__(self, cfg: OmegaConf):
         Attack.__init__(self, cfg, "attack_nearest")
-        self._priority = 1
 
     cdef unsigned char max_arg(self):
         return 0

--- a/mettagrid/actions/swap.pyx
+++ b/mettagrid/actions/swap.pyx
@@ -26,6 +26,8 @@ cdef class Swap(MettaActionHandler):
             actor.location,
         <Orientation>actor.orientation
         )
+        # xcxc we should ensure this is an agent. We're not just looking on the agent layer.
+        # Maybe the assertion that the target is frozen is enough?
         cdef Agent *target = <Agent*>self.env._grid.object_at(target_loc)
         if target == NULL:
             return False

--- a/mettagrid/actions/swap.pyx
+++ b/mettagrid/actions/swap.pyx
@@ -26,8 +26,6 @@ cdef class Swap(MettaActionHandler):
             actor.location,
         <Orientation>actor.orientation
         )
-        # xcxc we should ensure this is an agent. We're not just looking on the agent layer.
-        # Maybe the assertion that the target is frozen is enough?
         cdef Agent *target = <Agent*>self.env._grid.object_at(target_loc)
         if target == NULL:
             return False

--- a/mettagrid/mettagrid.pyx
+++ b/mettagrid/mettagrid.pyx
@@ -19,6 +19,7 @@ from mettagrid.actions.move import Move
 from mettagrid.actions.rotate import Rotate
 from mettagrid.actions.use import Use
 from mettagrid.actions.attack import Attack
+from mettagrid.actions.attack_nearest import AttackNearest
 from mettagrid.actions.shield import Shield
 from mettagrid.actions.gift import Gift
 from mettagrid.actions.noop import Noop
@@ -51,6 +52,7 @@ cdef class MettaGrid(GridEnv):
             actions.append(Use(cfg.actions.use))
         if cfg.actions.attack.enabled:
             actions.append(Attack(cfg.actions.attack))
+            actions.append(AttackNearest(cfg.actions.attack))
         if cfg.actions.shield.enabled:
             actions.append(Shield(cfg.actions.shield))
         if cfg.actions.gift.enabled:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ ext_modules = [
     build_ext(["mettagrid/observation_encoder.pyx"]),
     build_ext(["mettagrid/actions/actions.pyx"]),
     build_ext(["mettagrid/actions/attack.pyx"]),
+    build_ext(["mettagrid/actions/attack_nearest.pyx"]),
     build_ext(["mettagrid/actions/gift.pyx"]),
     build_ext(["mettagrid/actions/move.pyx"]),
     build_ext(["mettagrid/actions/noop.pyx"]),

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -71,6 +71,9 @@ def main(cfg):
     (obs, rewards, terminated, truncated, infos) = mettaGridEnv.step([[0,0]]*5)
     assert mettaGridEnv._c_env.current_timestep() == 1
     print("obs: ", obs)
+    # We have 5 agents, 22 channels, 11x11 grid
+    # This is fragile, and will need to be updated if the observation space changes.
+    # If you're updating this, please consider changing it to make it more robust.
     assert obs.shape == (5, 22, 11, 11)
     print("rewards: ", rewards)
     assert rewards.shape == (5,)
@@ -94,9 +97,16 @@ def main(cfg):
     print("mettaGridEnv._max_steps: ", mettaGridEnv._max_steps)
     assert mettaGridEnv._max_steps == 5000
     print("mettaGridEnv.single_observation_space: ", mettaGridEnv.single_observation_space)
+    # Here's our 22 channels, 11x11 grid again!
     assert mettaGridEnv.single_observation_space.shape == (22, 11, 11)
     print("mettaGridEnv.single_action_space: ", mettaGridEnv.single_action_space)
-    assert mettaGridEnv.single_action_space.nvec.tolist() == [8, 9]
+    [num_actions, max_arg] = mettaGridEnv.single_action_space.nvec.tolist()
+    # We don't want to hard-code the number of actions to expect (we might add more), so
+    # we do some loose testing of "is this a reasonable number of actions?"
+    assert 5 <= num_actions <= 20, f"num_actions: {num_actions}"
+    # Same this for max_arg. No reason the it's "reasonable range" should be the same as num_actions,
+    # but it happens to be.
+    assert 5 <= max_arg <= 20, f"max_arg: {max_arg}"
     print("mettaGridEnv.action_names(): ", mettaGridEnv.action_names())
     print("mettaGridEnv.grid_features: ", mettaGridEnv.grid_features)
     print("mettaGridEnv.global_features: ", mettaGridEnv.global_features)


### PR DESCRIPTION
This action attacks the nearest agent within the normal 3x3 attack grid. The intention here is to make attacking easier to learn. It currently uses the same config as attacks.

The main thing I want to test is how much this is used vs attack. Presumably the improved accuracy of this vs attack should mean it's favored by policies, and replaces attacks.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1209230969804461/1209335421215149) by [Unito](https://www.unito.io)
