### PR TITLE
Fixed mem-leak on environment reset

### DIFF
--- a/mettagrid/grid.hpp
+++ b/mettagrid/grid.hpp
@@ -30,13 +30,11 @@ class Grid {
         }
 
         inline ~Grid() {
-            printf("Grid destructor called: grid %p num_objects %lu\n", this, objects.size());
-            // for (unsigned long id = 1; id < objects.size(); ++id) {
-            //     if (objects[id] != nullptr) {
-            //         printf("Deleting object %lu (%p)\n", id, objects[id]);
-            //         objects[id] = nullptr;
-            //     }
-            // }
+            for (unsigned long id = 1; id < objects.size(); ++id) {
+                if (objects[id] != nullptr) {
+                    delete objects[id];
+                }
+            }
         }
 
         inline char add_object(GridObject * obj) {

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -81,6 +81,9 @@ cdef class GridEnv:
             np.zeros(max_agents, dtype=np.int8),
             np.zeros(max_agents, dtype=np.float32)
         )
+    
+    def __dealloc__(self):
+        del self._grid
 
     cdef void add_agent(self, GridObject* agent):
         self._agents.push_back(agent)

--- a/mettagrid/grid_object.hpp
+++ b/mettagrid/grid_object.hpp
@@ -36,6 +36,8 @@ class GridObject {
         GridLocation location;
         TypeId _type_id;
 
+        virtual ~GridObject() = default;
+
         inline void init(TypeId type_id, const GridLocation &loc) {
             this->_type_id = type_id;
             this->location = loc;

--- a/scripts/build_asan.sh
+++ b/scripts/build_asan.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+CFLAGS="-fsanitize=address -g" CXXFLAGS="-fsanitize=address -g" python setup.py build_ext --inplace --force

--- a/scripts/test_leaks.sh
+++ b/scripts/test_leaks.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+LD_PRELOAD="$(gcc -print-file-name=libasan.so) $(gcc -print-file-name=libstdc++.so)" ASAN_OPTIONS=detect_leaks=1 python ./tests/test_leaks.py

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -1,0 +1,23 @@
+import hydra
+import numpy as np
+
+# Make sure all modules import without errors:
+from mettagrid.mettagrid_env import MettaGridEnv
+
+# Make sure all dependencies are installed:
+import hydra
+
+@hydra.main(version_base=None, config_path="../configs", config_name="test_basic")
+def main(cfg):
+    # Create the environment:
+    mettaGridEnv = MettaGridEnv(render_mode=None, **cfg)
+
+    # reset the environment a few times to make sure no memory is leaked:
+    for _ in range(10):
+        mettaGridEnv.reset()
+    
+    mettaGridEnv = None
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Added code to deallocate the grid and the objects within the grid to fix a memory-leak on environment reset
* Added a virtual destructor to grid object, otherwise it was not delectable from a reference to the base class, i.e no polymorphic delete.
* Added scripts to build and test with asan, these were tested on linux but it should be possible to run on macos as well if the script is adapted for clang.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1209230969804461/1209346718013665) by [Unito](https://www.unito.io)
