### PR TITLE
Pixel perfect font rendering

### DIFF
--- a/mettagrid/renderer/raylib/font_renderer.py
+++ b/mettagrid/renderer/raylib/font_renderer.py
@@ -1,0 +1,34 @@
+from raylib import rl, colors
+
+
+class FontRenderer:
+    def __init__(self, ffi, font_path: str):
+        self.ffi = ffi
+        self.font_path = font_path
+        self.fonts = {}
+    
+    def get(self, size: int):
+        """
+        Loads the font at the given size if it is not already loaded.
+        """
+
+        if size not in self.fonts:
+            self.fonts[size] = rl.LoadFontEx(self.font_path.encode(), size, self.ffi.NULL, 0)
+        return self.fonts[size]
+
+    def render_text(self, text: str, x: int, y: int, size: int, color=colors.WHITE):
+        font = self.get(size)
+        rl.DrawTextEx(font, text.encode(), (x, y), size, 1, color)
+
+    def measure_text(self, text: str, size: int):
+        font = self.get(size)
+        return rl.MeasureTextEx(font, text.encode(), size, 1)
+
+    def render_text_right_aligned(self, text: str, x: int, y: int, size: int, color=colors.WHITE):
+        text_size = self.measure_text(text, size)
+        self.render_text(text, x - text_size.x, y, size, color)
+
+    def unload(self):
+        for font in self.fonts.values():
+            rl.UnloadFont(font)
+


### PR DESCRIPTION
* Created font renderer class to manage rendering fonts at different sizes
* When a font is loaded from a ttf file it's rendered to a raster image meaning it is only pixel perfect at the size it was loaded at

Before:
![Screenshot_20250206_202341](https://github.com/user-attachments/assets/d553d861-a469-4314-a63f-b28008c89323)

After:
![Screenshot_20250206_202054](https://github.com/user-attachments/assets/2c455bab-9373-495c-b915-daa8691a1505)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1209230969804461/1209347128435533) by [Unito](https://www.unito.io)
