### PR TITLE
clean up obs functions

### DIFF
--- a/mettagrid/base_encoder.pxd
+++ b/mettagrid/base_encoder.pxd
@@ -3,9 +3,7 @@
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 
-from mettagrid.grid_object cimport GridObject
-
-ctypedef unsigned char ObsType
+from mettagrid.grid_object cimport GridObject, ObsType
 
 cdef class ObservationEncoder:
     cdef:

--- a/mettagrid/grid_object.hpp
+++ b/mettagrid/grid_object.hpp
@@ -9,6 +9,7 @@ using namespace std;
 typedef unsigned short Layer;
 typedef unsigned short TypeId;
 typedef unsigned int GridCoord;
+typedef unsigned char ObsType;
 
 class GridLocation {
     public:
@@ -38,19 +39,20 @@ class GridObject {
 
         virtual ~GridObject() = default;
 
-        inline void init(TypeId type_id, const GridLocation &loc) {
+        void init(TypeId type_id, const GridLocation &loc) {
             this->_type_id = type_id;
             this->location = loc;
         }
 
-        inline void init(TypeId type_id, GridCoord r, GridCoord c) {
+        void init(TypeId type_id, GridCoord r, GridCoord c) {
             init(type_id, GridLocation(r, c, 0));
         }
 
-        inline void init(TypeId type_id, GridCoord r, GridCoord c, Layer layer) {
+        void init(TypeId type_id, GridCoord r, GridCoord c, Layer layer) {
             init(type_id, GridLocation(r, c, layer));
         }
 
+        virtual void obs(ObsType *obs) const = 0;
 };
 
 #endif // GRID_OBJECT_HPP

--- a/mettagrid/grid_object.pxd
+++ b/mettagrid/grid_object.pxd
@@ -21,6 +21,8 @@ cdef extern from "grid_object.hpp":
 
     ctypedef unsigned int GridObjectId
 
+    ctypedef unsigned char ObsType
+
     cdef cppclass GridObject:
         GridObjectId id
         GridLocation location
@@ -29,4 +31,5 @@ cdef extern from "grid_object.hpp":
         GridObject()
         void __dealloc__()
         void init(TypeId type_id, const GridLocation &loc)
+        void obs(ObsType *obs)
 

--- a/mettagrid/objects/agent.hpp
+++ b/mettagrid/objects/agent.hpp
@@ -7,7 +7,6 @@
 #include "../stats_tracker.hpp"
 #include "constants.hpp"
 #include "metta_object.hpp"
-typedef unsigned char ObsType;
 
 class Agent : public MettaObject {
 public:
@@ -94,7 +93,7 @@ public:
         this->current_resource_reward = new_reward;
     }
 
-    inline void obs(ObsType* obs) const {
+    virtual void obs(ObsType* obs) const override {
         obs[0] = 1;
         obs[1] = group;
         obs[2] = hp;

--- a/mettagrid/objects/agent.pxd
+++ b/mettagrid/objects/agent.pxd
@@ -1,12 +1,10 @@
 from libcpp.map cimport map
 from libcpp.vector cimport vector
 from libcpp.string cimport string
-from mettagrid.grid_object cimport GridCoord, GridLocation, GridObject
+from mettagrid.grid_object cimport GridCoord
 from mettagrid.stats_tracker cimport StatsTracker
 from .constants cimport InventoryItem
 from .metta_object cimport MettaObject, ObjectConfig
-from mettagrid.objects.constants cimport InventoryItemNames
-from mettagrid.observation_encoder cimport ObsType
 
 cdef extern from "agent.hpp":
     cdef cppclass Agent(MettaObject):
@@ -31,8 +29,6 @@ cdef extern from "agent.hpp":
             map[string, float] rewards)
 
         void update_inventory(InventoryItem item, short amount, float *reward)
-
-        void obs(ObsType *obs)
 
         @staticmethod
         inline vector[string] feature_names()

--- a/mettagrid/objects/altar.hpp
+++ b/mettagrid/objects/altar.hpp
@@ -8,8 +8,6 @@
 #include "agent.hpp"
 #include "constants.hpp"
 
-typedef unsigned char ObsType;
-
 class Altar : public Usable {
 public:
     Altar(GridCoord r, GridCoord c, ObjectConfig cfg) {
@@ -34,7 +32,7 @@ public:
             InventoryItemNames[InventoryItem::heart], 3);
     }
 
-    inline void obs(ObsType *obs) {
+    void obs(ObsType *obs) const override {
         obs[0] = 1;
         obs[1] = hp;
         obs[2] = ready;

--- a/mettagrid/objects/altar.pxd
+++ b/mettagrid/objects/altar.pxd
@@ -1,15 +1,12 @@
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from mettagrid.grid_object cimport GridCoord
-from mettagrid.observation_encoder cimport ObsType
 from .metta_object cimport ObjectConfig
 from .usable cimport Usable
 
 cdef extern from "altar.hpp":
     cdef cppclass Altar(Usable):
         Altar(GridCoord r, GridCoord c, ObjectConfig cfg) except +
-
-        void obs(ObsType *obs)
 
         @staticmethod
         vector[string] feature_names()

--- a/mettagrid/objects/armory.hpp
+++ b/mettagrid/objects/armory.hpp
@@ -8,8 +8,6 @@
 #include "agent.hpp"
 #include "constants.hpp"
 
-typedef unsigned char ObsType;
-
 class Armory : public Usable {
 public:
     Armory(GridCoord r, GridCoord c, ObjectConfig cfg) {
@@ -36,7 +34,7 @@ public:
             InventoryItemNames[InventoryItem::armor], 3);
     }
 
-    inline void obs(ObsType* obs) const {
+    virtual void obs(ObsType* obs) const override {
         obs[0] = 1;
         obs[1] = hp;
         obs[2] = ready;

--- a/mettagrid/objects/armory.pxd
+++ b/mettagrid/objects/armory.pxd
@@ -3,13 +3,10 @@ from libcpp.string cimport string
 from mettagrid.grid_object cimport GridCoord
 from mettagrid.objects.usable cimport Usable
 from mettagrid.objects.metta_object cimport ObjectConfig
-from mettagrid.observation_encoder cimport ObsType
 
 cdef extern from "armory.hpp":
     cdef cppclass Armory(Usable):
         Armory(GridCoord r, GridCoord c, ObjectConfig cfg) except +
-
-        void obs(ObsType *obs)
 
         @staticmethod
         vector[string] feature_names()

--- a/mettagrid/objects/factory.hpp
+++ b/mettagrid/objects/factory.hpp
@@ -8,8 +8,6 @@
 #include "agent.hpp"
 #include "constants.hpp"
 
-typedef unsigned char ObsType;
-
 class Factory : public Usable {
 public:
     Factory(GridCoord r, GridCoord c, ObjectConfig cfg) {
@@ -37,7 +35,7 @@ public:
         actor->stats.add(InventoryItemNames[InventoryItem::laser], "created", 5);
     }
 
-    inline void obs(ObsType* obs) const {
+    virtual void obs(ObsType* obs) const override {
         obs[0] = 1;
         obs[1] = hp;
         obs[2] = ready;

--- a/mettagrid/objects/factory.pxd
+++ b/mettagrid/objects/factory.pxd
@@ -9,8 +9,5 @@ cdef extern from "factory.hpp":
     cdef cppclass Factory(Usable):
         Factory(GridCoord r, GridCoord c, ObjectConfig cfg) except +
 
-
-        void obs(ObsType *obs)
-
         @staticmethod
         vector[string] feature_names()

--- a/mettagrid/objects/generator.hpp
+++ b/mettagrid/objects/generator.hpp
@@ -8,8 +8,6 @@
 #include "agent.hpp"
 #include "constants.hpp"
 
-typedef unsigned char ObsType;
-
 class Generator : public Usable {
 public:
     Generator(GridCoord r, GridCoord c, ObjectConfig cfg) {
@@ -35,7 +33,7 @@ public:
         actor->stats.incr(InventoryItemNames[InventoryItem::battery], "created");
     }
 
-    inline void obs(ObsType *obs) {
+    void obs(ObsType *obs) const override {
         obs[0] = 1;
         obs[1] = this->hp;
         obs[2] = this->ready;

--- a/mettagrid/objects/generator.pxd
+++ b/mettagrid/objects/generator.pxd
@@ -1,15 +1,12 @@
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from mettagrid.grid_object cimport GridCoord
-from mettagrid.observation_encoder cimport ObsType
 from .metta_object cimport ObjectConfig
 from .usable cimport Usable
 
 cdef extern from "generator.hpp":
     cdef cppclass Generator(Usable):
         Generator(GridCoord r, GridCoord c, ObjectConfig cfg) except +
-
-        void obs(ObsType *obs)
 
         @staticmethod
         vector[string] feature_names()

--- a/mettagrid/objects/lab.hpp
+++ b/mettagrid/objects/lab.hpp
@@ -8,8 +8,6 @@
 #include "agent.hpp"
 #include "constants.hpp"
 
-typedef unsigned char ObsType;
-
 class Lab : public Usable {
 public:
     Lab(GridCoord r, GridCoord c, ObjectConfig cfg) {
@@ -43,7 +41,7 @@ public:
             InventoryItemNames[InventoryItem::blueprint], 3);
     }
 
-    inline void obs(ObsType* obs) const {
+    virtual void obs(ObsType* obs) const override {
         obs[0] = 1;
         obs[1] = hp;
         obs[2] = ready;

--- a/mettagrid/objects/lab.pxd
+++ b/mettagrid/objects/lab.pxd
@@ -1,18 +1,12 @@
-# distutils: language=c++
-# cython: warn.undeclared=False
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
-from mettagrid.grid_object cimport GridCoord, GridLocation
+from mettagrid.grid_object cimport GridCoord
 from mettagrid.objects.usable cimport Usable
-from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.metta_object cimport ObjectConfig
-from mettagrid.observation_encoder cimport ObsType
+
 cdef extern from "lab.hpp":
     cdef cppclass Lab(Usable):
         Lab(GridCoord r, GridCoord c, ObjectConfig cfg) except +
-        bint usable(const Agent *actor)
 
-        void obs(ObsType *obs)
         @staticmethod
         vector[string] feature_names()

--- a/mettagrid/objects/lasery.hpp
+++ b/mettagrid/objects/lasery.hpp
@@ -8,8 +8,6 @@
 #include "agent.hpp"
 #include "constants.hpp"
 
-typedef unsigned char ObsType;
-
 class Lasery : public Usable {
 public:
     Lasery(GridCoord r, GridCoord c, ObjectConfig cfg) {
@@ -42,7 +40,7 @@ public:
             InventoryItemNames[InventoryItem::laser], 2);
     }
 
-    inline void obs(ObsType* obs) const {
+    virtual void obs(ObsType* obs) const override {
         obs[0] = 1;
         obs[1] = hp;
         obs[2] = ready;

--- a/mettagrid/objects/lasery.pxd
+++ b/mettagrid/objects/lasery.pxd
@@ -1,20 +1,12 @@
-# distutils: language=c++
-# cython: warn.undeclared=False
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
-from mettagrid.grid_object cimport GridCoord, GridLocation
+from mettagrid.grid_object cimport GridCoord
 from mettagrid.objects.usable cimport Usable
-from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.metta_object cimport ObjectConfig
-from mettagrid.observation_encoder cimport ObsType
 
 cdef extern from "lasery.hpp":
     cdef cppclass Lasery(Usable):
         Lasery(GridCoord r, GridCoord c, ObjectConfig cfg) except +
-        bint usable(const Agent *actor)
-
-        void obs(ObsType *obs)
 
         @staticmethod
         vector[string] feature_names()

--- a/mettagrid/objects/mine.hpp
+++ b/mettagrid/objects/mine.hpp
@@ -8,8 +8,6 @@
 #include "agent.hpp"
 #include "constants.hpp"
 
-typedef unsigned char ObsType;
-
 class Mine : public Usable {
 public:
     Mine(GridCoord r, GridCoord c, ObjectConfig cfg) {
@@ -27,7 +25,7 @@ public:
         actor->stats.incr(InventoryItemNames[InventoryItem::ore], "created");
     }
 
-    inline void obs(ObsType* obs) const {
+    virtual void obs(ObsType* obs) const override {
         obs[0] = 1;
         obs[1] = hp;
         obs[2] = ready;

--- a/mettagrid/objects/mine.pxd
+++ b/mettagrid/objects/mine.pxd
@@ -1,19 +1,12 @@
-# distutils: language=c++
-# cython: warn.undeclared=False
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
-from mettagrid.grid_object cimport GridCoord, GridLocation
+from mettagrid.grid_object cimport GridCoord
 from mettagrid.objects.usable cimport Usable
-from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.metta_object cimport ObjectConfig
-from mettagrid.observation_encoder cimport ObsType
 
 cdef extern from "mine.hpp":
     cdef cppclass Mine(Usable):
         Mine(GridCoord r, GridCoord c, ObjectConfig cfg) except +
-
-        void obs(ObsType *obs)
 
         @staticmethod
         vector[string] feature_names()

--- a/mettagrid/objects/temple.hpp
+++ b/mettagrid/objects/temple.hpp
@@ -8,8 +8,6 @@
 #include "agent.hpp"
 #include "constants.hpp"
 
-typedef unsigned char ObsType;
-
 class Temple : public Usable {
 public:
     Temple(GridCoord r, GridCoord c, ObjectConfig cfg) {
@@ -34,7 +32,7 @@ public:
         actor->stats.add(InventoryItemNames[InventoryItem::heart], "created", 5);
     }
 
-    inline void obs(ObsType* obs) const {
+    virtual void obs(ObsType* obs) const override {
         obs[0] = 1;
         obs[1] = hp;
         obs[2] = ready;

--- a/mettagrid/objects/temple.pxd
+++ b/mettagrid/objects/temple.pxd
@@ -1,19 +1,12 @@
-# distutils: language=c++
-# cython: warn.undeclared=False
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
-from mettagrid.grid_object cimport GridCoord, GridLocation
+from mettagrid.grid_object cimport GridCoord
 from mettagrid.objects.usable cimport Usable
-from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.metta_object cimport ObjectConfig
-from mettagrid.observation_encoder cimport ObsType
 
 cdef extern from "temple.hpp":
     cdef cppclass Temple(Usable):
         Temple(GridCoord r, GridCoord c, ObjectConfig cfg) except +
-
-        void obs(ObsType *obs)
 
         @staticmethod
         vector[string] feature_names()

--- a/mettagrid/objects/wall.hpp
+++ b/mettagrid/objects/wall.hpp
@@ -8,8 +8,6 @@
 #include "agent.hpp"
 #include "constants.hpp"
 
-typedef unsigned char ObsType;
-
 class Wall : public MettaObject {
 public:
     Wall(GridCoord r, GridCoord c, ObjectConfig cfg) {
@@ -17,7 +15,7 @@ public:
         MettaObject::init_mo(cfg);
     }
 
-    inline void obs(ObsType *obs) {
+    void obs(ObsType *obs) const override {
         obs[0] = 1;
         obs[1] = this->hp;
     }

--- a/mettagrid/objects/wall.pxd
+++ b/mettagrid/objects/wall.pxd
@@ -1,15 +1,11 @@
 from libcpp.vector cimport vector
 from libcpp.string cimport string
-from mettagrid.grid_object cimport GridCoord, GridLocation, GridObject
-from mettagrid.observation_encoder cimport ObsType
-from mettagrid.objects.constants cimport GridLayer, ObjectType
+from mettagrid.grid_object cimport GridCoord
 from mettagrid.objects.metta_object cimport MettaObject, ObjectConfig
 
 cdef extern from "wall.hpp":
     cdef cppclass Wall(MettaObject):
-        Wall(GridCoord r, GridCoord c, ObjectConfig cfg)
-
-        void obs(ObsType *obs)
+        Wall(GridCoord r, GridCoord c, ObjectConfig cfg) except +
 
         @staticmethod
         vector[string] feature_names()

--- a/mettagrid/observation_encoder.pyx
+++ b/mettagrid/observation_encoder.pyx
@@ -52,28 +52,7 @@ cdef class MettaObservationEncoder(ObservationEncoder):
         self._encode(obj, obs, self._offsets[obj._type_id])
 
     cdef _encode(self, GridObject *obj, ObsType[:] obs, unsigned int offset):
-        if obj._type_id == ObjectType.AgentT:
-            (<Agent*>obj).obs(&obs[offset])
-        elif obj._type_id == ObjectType.MineT:
-            (<Mine*>obj).obs(&obs[offset])
-        elif obj._type_id == ObjectType.WallT:
-            (<Wall*>obj).obs(&obs[offset])
-        elif obj._type_id == ObjectType.GeneratorT:
-            (<Generator*>obj).obs(&obs[offset])
-        elif obj._type_id == ObjectType.AltarT:
-            (<Altar*>obj).obs(&obs[offset])
-        elif obj._type_id == ObjectType.ArmoryT:
-            (<Armory*>obj).obs(&obs[offset])
-        elif obj._type_id == ObjectType.LaseryT:
-            (<Lasery*>obj).obs(&obs[offset])
-        elif obj._type_id == ObjectType.LabT:
-            (<Lab*>obj).obs(&obs[offset])
-        elif obj._type_id == ObjectType.FactoryT:
-            (<Factory*>obj).obs(&obs[offset])
-        elif obj._type_id == ObjectType.TempleT:
-            (<Temple*>obj).obs(&obs[offset])
-        else:
-            printf("Encoding object of unknown type: %d\n", obj._type_id)
+        obj.obs(&obs[offset])
 
     cdef vector[string] feature_names(self):
         return self._feature_names


### PR DESCRIPTION
We previously defined an inline observation function per object type, and then needed to use _type_id to figure out what casting to do in observation_encoder. I believe we had to do that since we'd been writing all functions in cython header files, and this requires the functions to be inline, and thus not virtual. Now that we're using (more) proper cpp, we can use virtual functions, and let someone else figure out which function we should be calling.

Tested this by playing mettagrid and mousing over things, and confirming that the observations still looked right.