### PR TITLE
add recipe_duration as distinct from cooldown, and initial_items

### DIFF
--- a/configs/mettagrid.yaml
+++ b/configs/mettagrid.yaml
@@ -31,9 +31,9 @@ game:
       # action_failure_penalty: 0.00001
       action_failure_penalty: 0
       ore: 0.005
-      ore_max: 100
+      ore_max: 5
       battery: 0.01
-      battery_max: 100
+      battery_max: 5
       heart: 1
       heart_max: 1000
 
@@ -83,27 +83,35 @@ game:
       input_battery: 3
       output_heart: 1
       max_output: 5
+      recipe_duration: 1
       cooldown: ${uniform:1, 20, 10}
+      initial_items: 1
 
     mine:
       hp: 30
       output_ore: 1
       max_output: 5
+      recipe_duration: 1
       cooldown: ${uniform:0, 100, 50}
+      initial_items: 1
 
     generator:
       hp: 30
       input_ore: 1
       output_battery: 1
       max_output: 5
+      recipe_duration: 1
       cooldown: ${uniform:0, 50, 25}
+      initial_items: 1
 
     armory:
       hp: 30
       input_ore: 3
       output_armor: 1
       max_output: 5
+      recipe_duration: 1
       cooldown: ${uniform:0, 20, 10}
+      initial_items: 1
 
     lasery:
       hp: 30
@@ -111,7 +119,9 @@ game:
       input_battery: 2
       output_laser: 1
       max_output: 5
+      recipe_duration: 1
       cooldown: ${uniform:0, 20, 10}
+      initial_items: 1
 
     lab:
       hp: 30
@@ -119,8 +129,9 @@ game:
       input_battery: 3
       output_blueprint: 1
       max_output: 5
+      recipe_duration: 1
       cooldown: ${uniform:0, 10, 5}
-
+      initial_items: 1
     factory:
       hp: 30
       input_blueprint: 1
@@ -129,7 +140,9 @@ game:
       output_armor: 5
       output_laser: 5
       max_output: 5
+      recipe_duration: 1
       cooldown: ${uniform:0, 10, 5}
+      initial_items: 1
 
     temple:
       hp: 30
@@ -137,7 +150,9 @@ game:
       input_blueprint: 1
       output_heart: 5
       max_output: 5
+      recipe_duration: 1
       cooldown: ${uniform:0, 10, 5}
+      initial_items: 1
 
     wall:
       hp: ${uniform:1, 20, 10}

--- a/configs/mettagrid.yaml
+++ b/configs/mettagrid.yaml
@@ -83,7 +83,7 @@ game:
       input_battery: 3
       output_heart: 1
       max_output: 5
-      recipe_duration: 1
+      conversion_ticks: 1
       cooldown: ${uniform:1, 20, 10}
       initial_items: 1
 
@@ -91,7 +91,7 @@ game:
       hp: 30
       output_ore: 1
       max_output: 5
-      recipe_duration: 1
+      conversion_ticks: 1
       cooldown: ${uniform:0, 100, 50}
       initial_items: 1
 
@@ -100,7 +100,7 @@ game:
       input_ore: 1
       output_battery: 1
       max_output: 5
-      recipe_duration: 1
+      conversion_ticks: 1
       cooldown: ${uniform:0, 50, 25}
       initial_items: 1
 
@@ -109,7 +109,7 @@ game:
       input_ore: 3
       output_armor: 1
       max_output: 5
-      recipe_duration: 1
+      conversion_ticks: 1
       cooldown: ${uniform:0, 20, 10}
       initial_items: 1
 
@@ -119,7 +119,7 @@ game:
       input_battery: 2
       output_laser: 1
       max_output: 5
-      recipe_duration: 1
+      conversion_ticks: 1
       cooldown: ${uniform:0, 20, 10}
       initial_items: 1
 
@@ -129,7 +129,7 @@ game:
       input_battery: 3
       output_blueprint: 1
       max_output: 5
-      recipe_duration: 1
+      conversion_ticks: 1
       cooldown: ${uniform:0, 10, 5}
       initial_items: 1
     factory:
@@ -140,7 +140,7 @@ game:
       output_armor: 5
       output_laser: 5
       max_output: 5
-      recipe_duration: 1
+      conversion_ticks: 1
       cooldown: ${uniform:0, 10, 5}
       initial_items: 1
 
@@ -150,7 +150,7 @@ game:
       input_blueprint: 1
       output_heart: 5
       max_output: 5
-      recipe_duration: 1
+      conversion_ticks: 1
       cooldown: ${uniform:0, 10, 5}
       initial_items: 1
 

--- a/configs/simple.yaml
+++ b/configs/simple.yaml
@@ -19,7 +19,7 @@ game:
       agents: 6
 
       objects:
-        mine: ${uniform:1,10,5}
+        mine: ${uniform:1,20,10}
         generator: ${uniform:1,10,2}
         altar: ${uniform:1,5,1}
         armory: ${uniform:1,5,1}

--- a/mettagrid/config/config.py
+++ b/mettagrid/config/config.py
@@ -8,6 +8,7 @@ from omegaconf import OmegaConf
 from rich import traceback
 import warnings
 
+warnings.warn("This config.py file is deprecated", DeprecationWarning)
 
 def seed_everything(seed, torch_deterministic):
     random.seed(seed)

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -15,7 +15,8 @@ from mettagrid.grid_object cimport (
     GridLocation
 )
 from mettagrid.observation_encoder cimport ObservationEncoder, ObsType
-from mettagrid.objects.production_handler cimport ProductionHandler
+from mettagrid.objects.production_handler cimport ProductionHandler, CoolDownHandler
+
 # Constants
 obs_np_type = np.uint8
 
@@ -65,6 +66,7 @@ cdef class GridEnv:
         self._event_manager.init(self._grid, &self._stats)
         # The order of this needs to match the order in the Events enum
         self._event_manager.event_handlers.push_back(new ProductionHandler(&self._event_manager))
+        self._event_manager.event_handlers.push_back(new CoolDownHandler(&self._event_manager))
         self._track_last_action = track_last_action
 
         self.set_buffers(

--- a/mettagrid/mettagrid.pyx
+++ b/mettagrid/mettagrid.pyx
@@ -25,6 +25,7 @@ from mettagrid.objects.mine cimport Mine
 from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.production_handler cimport ProductionHandler
 from mettagrid.objects.wall cimport Wall
+from mettagrid.objects.converter cimport Converter
 from mettagrid.objects.generator cimport Generator
 from mettagrid.objects.altar cimport Altar
 from mettagrid.objects.lab cimport Lab
@@ -32,7 +33,8 @@ from mettagrid.objects.factory cimport Factory
 from mettagrid.objects.temple cimport Temple
 from mettagrid.objects.armory cimport Armory
 from mettagrid.objects.lasery cimport Lasery
-from mettagrid.objects.constants cimport ObjectLayers, InventoryItemNames, Events
+from mettagrid.objects.constants cimport ObjectLayers, InventoryItemNames
+
 
 # Action imports
 from mettagrid.actions.move import Move
@@ -102,62 +104,33 @@ cdef class MettaGrid(GridEnv):
         }
 
         cdef Agent *agent
+        cdef Converter *converter = NULL
         cdef string group_name
         cdef unsigned char group_id
         for r in range(map.shape[0]):
             for c in range(map.shape[1]):
 
                 if map[r,c] == "wall":
-                    self._grid.add_object(new Wall(r, c, cfg.objects.wall))
+                    wall = new Wall(r, c, cfg.objects.wall)
+                    self._grid.add_object(wall)
                     self._stats.incr(b"objects.wall")
 
                 elif map[r,c] == "mine":
-                    mine = new Mine(r, c, cfg.objects.mine)
-                    self._grid.add_object(mine)
-                    mine.set_event_manager(&self._event_manager)
-                    self._stats.incr(b"objects.mine")
-
+                    converter = new Mine(r, c, cfg.objects.mine)
                 elif map[r,c] == "generator":
-                    generator = new Generator(r, c, cfg.objects.generator)
-                    self._grid.add_object(generator)
-                    generator.set_event_manager(&self._event_manager)
-                    self._stats.incr(b"objects.generator")
-
+                    converter = new Generator(r, c, cfg.objects.generator)
                 elif map[r,c] == "altar":
-                    altar = new Altar(r, c, cfg.objects.altar)
-                    self._grid.add_object(altar)
-                    altar.set_event_manager(&self._event_manager)
-                    self._stats.incr(b"objects.altar")
-
+                    converter = new Altar(r, c, cfg.objects.altar)
                 elif map[r,c] == "armory":
-                    armory = new Armory(r, c, cfg.objects.armory)
-                    self._grid.add_object(armory)
-                    armory.set_event_manager(&self._event_manager)
-                    self._stats.incr(b"objects.armory")
-
+                    converter = new Armory(r, c, cfg.objects.armory)
                 elif map[r,c] == "lasery":
-                    lasery = new Lasery(r, c, cfg.objects.lasery)
-                    self._grid.add_object(lasery)
-                    lasery.set_event_manager(&self._event_manager)
-                    self._stats.incr(b"objects.lasery")
-
+                    converter = new Lasery(r, c, cfg.objects.lasery)
                 elif map[r,c] == "lab":
-                    lab = new Lab(r, c, cfg.objects.lab)
-                    self._grid.add_object(lab)
-                    lab.set_event_manager(&self._event_manager)
-                    self._stats.incr(b"objects.lab")
-
+                    converter = new Lab(r, c, cfg.objects.lab)
                 elif map[r,c] == "factory":
-                    factory = new Factory(r, c, cfg.objects.factory)
-                    self._grid.add_object(factory)
-                    factory.set_event_manager(&self._event_manager)
-                    self._stats.incr(b"objects.factory")
-
+                    converter = new Factory(r, c, cfg.objects.factory)
                 elif map[r,c] == "temple":
-                    temple = new Temple(r, c, cfg.objects.temple)
-                    self._grid.add_object(temple)
-                    temple.set_event_manager(&self._event_manager)
-                    self._stats.incr(b"objects.temple")
+                    converter = new Temple(r, c, cfg.objects.temple)
 
                 elif map[r,c].startswith("agent."):
                     group_name = map[r,c].split(".")[1]
@@ -175,6 +148,16 @@ cdef class MettaGrid(GridEnv):
                     agent.agent_id = self._agents.size()
                     self.add_agent(agent)
                     self._group_sizes[group_id] += 1
+
+                if converter != NULL:
+                    stat = "objects." + map[r,c]
+                    self._stats.incr(stat)
+                    self._grid.add_object(converter)
+                    converter.set_event_manager(&self._event_manager)
+                    converter = NULL
+
+
+
     cpdef list[str] grid_features(self):
         return self._grid_features
 

--- a/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid_env.py
@@ -11,10 +11,9 @@ from mettagrid.mettagrid_c import MettaGrid  # pylint: disable=E0611
 
 
 class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
-    def __init__(self, render_mode: str, buf=None, **cfg):
-
+    def __init__(self, env_cfg: OmegaConf, render_mode: str, buf=None, **kwargs):
         self._render_mode = render_mode
-        self._cfg = OmegaConf.create(cfg)
+        self._cfg = env_cfg
         self.make_env()
         self.should_reset = False
         self._renderer = None

--- a/mettagrid/objects/constants.hpp
+++ b/mettagrid/objects/constants.hpp
@@ -8,7 +8,8 @@
 #include "../grid_object.hpp"
 
 enum Events {
-    FinishConverting = 0
+    FinishConverting = 0,
+    CoolDown = 1
 };
 
 enum GridLayer {

--- a/mettagrid/objects/converter.hpp
+++ b/mettagrid/objects/converter.hpp
@@ -22,7 +22,7 @@ private:
         // We also need to have an id to schedule the finishing event. If our id
         // is zero, we probably haven't been added to the grid yet.
         assert(this->id != 0);
-        if (this->converting) {
+        if (this->converting || this->cooling_down) {
             return;
         }
         // Check if the converter is already at max output.
@@ -58,8 +58,10 @@ public:
     // the type it produces. This may be clunky in some cases, but the main usage
     // is to make Mines (etc) have a maximum output.
     unsigned short max_output;
-    unsigned char recipe_duration;
-    bool converting;
+    unsigned char recipe_duration; // Time to produce output
+    unsigned char cooldown;        // Time to wait after producing before starting again
+    bool converting;               // Currently in production phase
+    bool cooling_down;             // Currently in cooldown phase
     EventManager *event_manager;
 
     Converter(GridCoord r, GridCoord c, ObjectConfig cfg, TypeId type_id) {
@@ -73,8 +75,36 @@ public:
             this->recipe_output[i] = cfg["output_" + InventoryItemNames[i]];
         }
         this->max_output = cfg["max_output"];
-        this->recipe_duration = cfg["cooldown"];
+        this->recipe_duration = cfg["recipe_duration"];
+
+        // Make sure cooldown exists to prevent crashes, default to 0 if not provided
+        if (cfg.count("cooldown") > 0) {
+            this->cooldown = cfg["cooldown"];
+        } else {
+            this->cooldown = 0;
+        }
+
         this->converting = false;
+        this->cooling_down = false;
+
+        // Initialize inventory with initial_items for all output types
+        // Default to recipe_output values if initial_items is not present
+        unsigned char initial_items = 0;
+        if (cfg.count("initial_items") > 0) {
+            initial_items = cfg["initial_items"];
+            for (unsigned int i = 0; i < InventoryItem::InventoryCount; i++) {
+                if (this->recipe_output[i] > 0) {
+                    HasInventory::update_inventory(static_cast<InventoryItem>(i), initial_items, nullptr);
+                }
+            }
+        } else {
+            // Use recipe_output amounts as initial values if initial_items not specified
+            for (unsigned int i = 0; i < InventoryItem::InventoryCount; i++) {
+                if (this->recipe_output[i] > 0) {
+                    HasInventory::update_inventory(static_cast<InventoryItem>(i), this->recipe_output[i], nullptr);
+                }
+            }
+        }
     }
 
     Converter(GridCoord r, GridCoord c, ObjectConfig cfg) : Converter(r, c, cfg, ObjectType::GenericConverterT) {}
@@ -86,9 +116,27 @@ public:
 
     void finish_converting() {
         this->converting = false;
+
+        // Add output to inventory
         for (unsigned int i = 0; i < InventoryItem::InventoryCount; i++) {
-            this->update_inventory(static_cast<InventoryItem>(i), this->recipe_output[i], nullptr);
+            if (this->recipe_output[i] > 0) {
+                HasInventory::update_inventory(static_cast<InventoryItem>(i), this->recipe_output[i], nullptr);
+            }
         }
+
+        if (this->cooldown > 0) {
+            // Start cooldown phase
+            this->cooling_down = true;
+            this->event_manager->schedule_event(Events::CoolDown, this->cooldown, this->id, 0);
+        } else {
+            // No cooldown, try to start converting again immediately
+            this->maybe_start_converting();
+        }
+    }
+
+    void finish_cooldown() {
+        this->cooling_down = false;
+        this->maybe_start_converting();
     }
 
     void update_inventory(InventoryItem item, short amount, float *reward) override {
@@ -99,7 +147,7 @@ public:
     void obs(ObsType *obs, const std::vector<unsigned int> &offsets) const override {
         obs[offsets[0]] = 1;
         obs[offsets[1]] = this->hp;
-        obs[offsets[2]] = this->converting;
+        obs[offsets[2]] = this->converting || this->cooling_down;
         for (unsigned int i = 0; i < InventoryItem::InventoryCount; i++) {
             obs[offsets[3] + i] = this->inventory[i];
         }

--- a/mettagrid/objects/converter.hpp
+++ b/mettagrid/objects/converter.hpp
@@ -48,7 +48,7 @@ private:
         // All the previous returns were "we don't start converting".
         // This one is us starting to convert.
         this->converting = true;
-        this->event_manager->schedule_event(Events::FinishConverting, this->recipe_duration, this->id, 0);
+        this->event_manager->schedule_event(Events::FinishConverting, this->conversion_ticks, this->id, 0);
     }
 
 public:
@@ -58,7 +58,7 @@ public:
     // the type it produces. This may be clunky in some cases, but the main usage
     // is to make Mines (etc) have a maximum output.
     unsigned short max_output;
-    unsigned char recipe_duration; // Time to produce output
+    unsigned char conversion_ticks; // Time to produce output
     unsigned char cooldown;        // Time to wait after producing before starting again
     bool converting;               // Currently in production phase
     bool cooling_down;             // Currently in cooldown phase
@@ -75,7 +75,7 @@ public:
             this->recipe_output[i] = cfg["output_" + InventoryItemNames[i]];
         }
         this->max_output = cfg["max_output"];
-        this->recipe_duration = cfg["recipe_duration"];
+        this->conversion_ticks = cfg["conversion_ticks"];
 
         // Make sure cooldown exists to prevent crashes, default to 0 if not provided
         if (cfg.count("cooldown") > 0) {

--- a/mettagrid/objects/converter.pxd
+++ b/mettagrid/objects/converter.pxd
@@ -11,7 +11,7 @@ cdef extern from "converter.hpp":
         vector[unsigned char] recipe_output
         unsigned short max_output
         unsigned char type
-        unsigned char recipe_duration
+        unsigned char conversion_ticks
         bint converting
 
         Converter(GridCoord r, GridCoord c, ObjectConfig cfg)

--- a/mettagrid/objects/production_handler.hpp
+++ b/mettagrid/objects/production_handler.hpp
@@ -2,10 +2,12 @@
 #define PRODUCTION_HANDLER_HPP
 
 #include "converter.hpp"
-#include "grid.hpp"
-#include "stats_tracker.hpp"
+#include "../grid.hpp"
+#include "../stats_tracker.hpp"
 #include "constants.hpp"
-#include "event.hpp"
+#include "../event.hpp"
+
+// Handles the FinishConverting event
 class ProductionHandler : public EventHandler {
 public:
     ProductionHandler(EventManager* event_manager) : EventHandler(event_manager) {}
@@ -21,5 +23,19 @@ public:
     }
 };
 
+// Handles the CoolDown event
+class CoolDownHandler : public EventHandler {
+public:
+    CoolDownHandler(EventManager* event_manager) : EventHandler(event_manager) {}
+
+    void handle_event(GridObjectId obj_id, EventArg arg) override {
+        Converter* converter = static_cast<Converter*>(this->event_manager->grid->object(obj_id));
+        if (!converter) {
+            return;
+        }
+
+        converter->finish_cooldown();
+    }
+};
 
 #endif // PRODUCTION_HANDLER_HPP

--- a/mettagrid/objects/production_handler.pxd
+++ b/mettagrid/objects/production_handler.pxd
@@ -8,3 +8,8 @@ cdef extern from "production_handler.hpp":
         ProductionHandler(EventManager *event_manager)
 
         void handle_event(GridObjectId obj_id, EventArg arg)
+
+    cdef cppclass CoolDownHandler(EventHandler):
+        CoolDownHandler(EventManager *event_manager)
+
+        void handle_event(GridObjectId obj_id, EventArg arg)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -45,7 +45,7 @@ import tqdm
 def main(cfg):
 
     # Create the environment:
-    mettaGridEnv = mettagrid.mettagrid_env.MettaGridEnv(render_mode=None, **cfg)
+    mettaGridEnv = mettagrid.mettagrid_env.MettaGridEnv(cfg, render_mode=None)
 
     # Make sure the environment was created correctly:
     print("mettaGridEnv._renderer: ", mettaGridEnv._renderer)


### PR DESCRIPTION
Converters now can start with initial_items worth of output. They also take conversion_ticks to convert, and then wait cooldown to start converting again. This allows control of supply separately from credit assignment delay