### PR TITLE
Allow raylib_renderer to run without policy; show_map script

### DIFF
--- a/tests/show_map.py
+++ b/tests/show_map.py
@@ -1,0 +1,20 @@
+import os
+import signal  # Aggressively exit on ctrl+c
+
+import hydra
+from mettagrid.mettagrid_env import MettaGridEnv
+from mettagrid.renderer.raylib.raylib_renderer import MettaGridRaylibRenderer
+
+signal.signal(signal.SIGINT, lambda sig, frame: os._exit(0))
+
+@hydra.main(version_base=None, config_path="../configs", config_name="simple")
+def main(cfg):
+    env = MettaGridEnv(cfg, render_mode="human")
+    renderer = MettaGridRaylibRenderer(env._c_env, env._env_cfg.game)
+
+    while True:
+        renderer.render_and_wait()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Context: I wanted to run the viewer from mettagrid repo, without `tools.play` script from metta repo.

Why:
- `tools.play` loads a policy, and in most configurations would involve wandb, which is slower to start
- this seems like something that should generally be possible

So I've updated the renderer so that it won't crash if `update()` is not called. Which is enough for my purposes of viewing the map.

Also added a `tests.show_map` script to run it in this minimal configuration.