### PR TITLE
Make ObjectTypeName and ObjectType be consistent

### DIFF
--- a/mettagrid/objects/constants.hpp
+++ b/mettagrid/objects/constants.hpp
@@ -17,6 +17,13 @@ enum GridLayer {
     Object_Layer = 1
 };
 
+// There should be a one-to-one mapping between ObjectType and ObjectTypeNames.
+// ObjectTypeName is mostly used for human-readability, but may be used as a key
+// in config files, etc. Agents will be able to see an object's type_id.
+//
+// Note that ObjectType does _not_ have to correspond to an object's class (which
+// is a C++ concept). In particular, multiple ObjectTypes may correspond to the
+// same class.
 enum ObjectType {
     AgentT = 0,
     WallT = 1,

--- a/mettagrid/objects/constants.hpp
+++ b/mettagrid/objects/constants.hpp
@@ -32,9 +32,23 @@ enum ObjectType {
     Count = 11
 };
 
+std::vector<std::string> ObjectTypeNames = {
+    "agent",
+    "wall",
+    "mine",
+    "generator",
+    "altar",
+    "armory",
+    "lasery",
+    "lab",
+    "factory",
+    "temple",
+    "converter"
+};
+
 enum InventoryItem {
     ore_red = 0,
-    ore_blue =1,
+    ore_blue = 1,
     ore_green = 2,
     battery = 3,
     heart = 4,
@@ -54,25 +68,6 @@ std::vector<std::string> InventoryItemNames = {
     "armor",
     "laser",
     "blueprint"
-};
-
-std::vector<std::string> ObjectTypeNames = {
-    "agent",
-    "wall",
-    "block",
-    "mine.red",
-    "mine.blue",
-    "mine.green",
-    "generator.red",
-    "generator.blue",
-    "generator.green",
-    "altar",
-    "armory",
-    "lasery",
-    "lab",
-    "factory",
-    "temple",
-    "converter"
 };
 
 std::map<TypeId, GridLayer> ObjectLayers = {

--- a/mettagrid/objects/production_handler.pxd
+++ b/mettagrid/objects/production_handler.pxd
@@ -1,7 +1,5 @@
 from mettagrid.event cimport EventHandler, EventArg, EventManager
 from mettagrid.grid_object cimport GridObjectId
-from .constants cimport ObjectTypeNames, Events
-from .converter cimport Converter
 
 cdef extern from "production_handler.hpp":
     cdef cppclass ProductionHandler(EventHandler):


### PR DESCRIPTION
This reverts a change made as part of adding colors, and clarifies what's expected from these constants.

I've smoke tested training with this, but haven't tested the whole way through. I believe this should fix some stats issues by correcting what happens when you look up an object's name by type_id, but haven't confirmed this. I think the net effect should be pretty contained, and I'm going to be iterating on this pretty immediately.