### PR TITLE
render_ascii for all objects; move ascii encoding to constants

### DIFF
--- a/mettagrid/grid_env.pxd
+++ b/mettagrid/grid_env.pxd
@@ -109,5 +109,5 @@ cdef class GridEnv:
     cpdef get_episode_rewards(self)
 
     cpdef tuple get_buffers(self)
-    cpdef cnp.ndarray render_ascii(self, list[char] type_to_char)
+    cpdef cnp.ndarray render_ascii(self)
     cpdef cnp.ndarray grid_objects_types(self)

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -16,7 +16,7 @@ from mettagrid.grid_object cimport (
 )
 from mettagrid.observation_encoder cimport ObservationEncoder, ObsType
 from mettagrid.objects.production_handler cimport ProductionHandler, CoolDownHandler
-from mettagrid.objects.constants cimport ObjectTypeNames
+from mettagrid.objects.constants cimport ObjectTypeNames, ObjectTypeAscii
 
 # Constants
 obs_np_type = np.uint8
@@ -278,12 +278,12 @@ cdef class GridEnv:
     cpdef tuple get_buffers(self):
         return (self._observations_np, self._terminals_np, self._truncations_np, self._rewards_np)
 
-    cpdef cnp.ndarray render_ascii(self, list[char] type_to_char):
+    cpdef cnp.ndarray render_ascii(self):
         cdef GridObject *obj
         grid = np.full((self._grid.height, self._grid.width), " ", dtype=np.str_)
         for obj_id in range(1, self._grid.objects.size()):
             obj = self._grid.object(obj_id)
-            grid[obj.location.r, obj.location.c] = type_to_char[obj._type_id]
+            grid[obj.location.r, obj.location.c] = ObjectTypeAscii[obj._type_id]
         return grid
 
     cpdef cnp.ndarray grid_objects_types(self):

--- a/mettagrid/mettagrid.pyx
+++ b/mettagrid/mettagrid.pyx
@@ -160,7 +160,6 @@ cdef class MettaGrid(GridEnv):
         return self._grid_features
 
     def render(self):
-        # must match
         grid = self.render_ascii()
         for r in grid:
                 print("".join(r))

--- a/mettagrid/mettagrid.pyx
+++ b/mettagrid/mettagrid.pyx
@@ -24,7 +24,7 @@ from mettagrid.observation_encoder cimport (
 from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.wall cimport Wall
 from mettagrid.objects.converter cimport Converter
-from mettagrid.objects.constants cimport ObjectLayers, InventoryItemNames, ObjectType
+from mettagrid.objects.constants cimport ObjectLayers, InventoryItemNames, ObjectType, ObjectTypeAscii
 
 # Action imports
 from mettagrid.actions.move import Move
@@ -160,7 +160,8 @@ cdef class MettaGrid(GridEnv):
         return self._grid_features
 
     def render(self):
-        grid = self.render_ascii(["A", "#", "g", "c", "a"])
+        # must match
+        grid = self.render_ascii()
         for r in grid:
                 print("".join(r))
 

--- a/mettagrid/objects/constants.hpp
+++ b/mettagrid/objects/constants.hpp
@@ -53,6 +53,20 @@ std::vector<std::string> ObjectTypeNames = {
     "converter"
 };
 
+std::vector<std::string> ObjectTypeAscii = {
+    "A",
+    "#",
+    "g",
+    "c",
+    "a",
+    "r",
+    "l",
+    "b",
+    "f",
+    "t",
+    "v"
+};
+
 enum InventoryItem {
     ore_red = 0,
     ore_blue = 1,

--- a/mettagrid/objects/constants.pxd
+++ b/mettagrid/objects/constants.pxd
@@ -39,4 +39,5 @@ cdef extern from "constants.hpp":
 
     cdef vector[string] InventoryItemNames
     cdef vector[string] ObjectTypeNames
+    cdef vector[string] ObjectTypeAscii
     cdef map[TypeId, GridLayer] ObjectLayers


### PR DESCRIPTION
Without this, `c_env.render` crashed on objects with id>5.