### PR TITLE
rename action -> action_handler

### DIFF
--- a/mettagrid/action_handler.pxd
+++ b/mettagrid/action_handler.pxd
@@ -3,9 +3,6 @@ from mettagrid.grid_env cimport GridEnv
 from libcpp.string cimport string
 
 ctypedef unsigned int ActionArg
-ctypedef struct Action:
-    unsigned int action
-    unsigned int arg
 
 cdef class ActionHandler:
     cdef GridEnv env

--- a/mettagrid/action_handler.pyx
+++ b/mettagrid/action_handler.pyx
@@ -1,4 +1,4 @@
-from mettagrid.action cimport ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.grid_env cimport GridEnv
 from mettagrid.grid_object cimport GridObjectId
 

--- a/mettagrid/actions/actions.pxd
+++ b/mettagrid/actions/actions.pxd
@@ -5,7 +5,7 @@ from libcpp.map cimport map
 from libcpp.vector cimport vector
 
 from mettagrid.grid_object cimport TypeId, GridObjectId
-from mettagrid.action cimport ActionHandler, ActionArg
+from mettagrid.action_handler cimport ActionHandler, ActionArg
 from mettagrid.objects.agent cimport Agent
 
 cdef struct StatNames:

--- a/mettagrid/actions/actions.pyx
+++ b/mettagrid/actions/actions.pyx
@@ -3,7 +3,7 @@ from libcpp.string cimport string
 
 from omegaconf import OmegaConf
 
-from mettagrid.action cimport ActionHandler, ActionArg
+from mettagrid.action_handler cimport ActionHandler, ActionArg
 from mettagrid.grid_object cimport GridObjectId
 from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.constants cimport ObjectTypeNames

--- a/mettagrid/actions/attack.pyx
+++ b/mettagrid/actions/attack.pyx
@@ -2,7 +2,7 @@ from libc.stdio cimport printf
 
 from omegaconf import OmegaConf
 
-from mettagrid.action cimport ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.actions.actions cimport MettaActionHandler
 from mettagrid.grid_object cimport GridLocation, Orientation
 from mettagrid.objects.agent cimport Agent

--- a/mettagrid/actions/attack_nearest.pyx
+++ b/mettagrid/actions/attack_nearest.pyx
@@ -2,7 +2,7 @@ from libc.stdio cimport printf
 
 from omegaconf import OmegaConf
 
-from mettagrid.action cimport ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.actions.attack cimport Attack
 from mettagrid.grid_object cimport GridLocation, Orientation
 from mettagrid.objects.agent cimport Agent, InventoryItem

--- a/mettagrid/actions/change_color.pxd
+++ b/mettagrid/actions/change_color.pxd
@@ -1,4 +1,4 @@
-from mettagrid.action cimport ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.objects.agent cimport Agent
 from mettagrid.actions.actions cimport MettaActionHandler
 

--- a/mettagrid/actions/change_color.pyx
+++ b/mettagrid/actions/change_color.pyx
@@ -2,9 +2,8 @@ from libc.stdio cimport printf
 
 from omegaconf import OmegaConf
 
-from mettagrid.action cimport ActionHandler, ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.actions.actions cimport MettaActionHandler
-from mettagrid.grid_object cimport GridObject
 from mettagrid.objects.agent cimport Agent
 
 cdef class ChangeColorAction(MettaActionHandler):

--- a/mettagrid/actions/get_output.pyx
+++ b/mettagrid/actions/get_output.pyx
@@ -2,7 +2,7 @@
 from omegaconf import OmegaConf
 
 from mettagrid.grid_object cimport GridLocation, Orientation
-from mettagrid.action cimport ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.metta_object cimport MettaObject
 from mettagrid.objects.constants cimport Events, GridLayer, InventoryItem, InventoryItemNames

--- a/mettagrid/actions/move.pyx
+++ b/mettagrid/actions/move.pyx
@@ -2,7 +2,7 @@ from libc.stdio cimport printf
 
 from omegaconf import OmegaConf
 
-from mettagrid.action cimport ActionHandler, ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.actions.actions cimport MettaActionHandler
 from mettagrid.grid_object cimport (
     GridLocation,

--- a/mettagrid/actions/noop.pyx
+++ b/mettagrid/actions/noop.pyx
@@ -2,14 +2,8 @@ from libc.stdio cimport printf
 
 from omegaconf import OmegaConf
 
-from mettagrid.action cimport ActionHandler, ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.actions.actions cimport MettaActionHandler
-from mettagrid.grid_object cimport (
-    GridLocation,
-    GridObject,
-    GridObjectId,
-    Orientation
-)
 from mettagrid.objects.agent cimport Agent
 
 cdef class Noop(MettaActionHandler):

--- a/mettagrid/actions/put_recipe_items.pyx
+++ b/mettagrid/actions/put_recipe_items.pyx
@@ -2,7 +2,7 @@
 from omegaconf import OmegaConf
 
 from mettagrid.grid_object cimport GridLocation, Orientation
-from mettagrid.action cimport ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.metta_object cimport MettaObject
 from mettagrid.objects.constants cimport Events, GridLayer, InventoryItem, InventoryItemNames

--- a/mettagrid/actions/rotate.pyx
+++ b/mettagrid/actions/rotate.pyx
@@ -2,9 +2,8 @@ from libc.stdio cimport printf
 
 from omegaconf import OmegaConf
 
-from mettagrid.action cimport ActionHandler, ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.actions.actions cimport MettaActionHandler
-from mettagrid.grid_object cimport GridLocation, Orientation
 from mettagrid.objects.agent cimport Agent
 
 cdef class Rotate(MettaActionHandler):

--- a/mettagrid/actions/swap.pyx
+++ b/mettagrid/actions/swap.pyx
@@ -4,10 +4,9 @@ from libc.stdio cimport printf
 from omegaconf import OmegaConf
 
 from mettagrid.grid_object cimport GridLocation, Orientation
-from mettagrid.action cimport ActionArg
+from mettagrid.action_handler cimport ActionArg
 from mettagrid.objects.agent cimport Agent
 from mettagrid.grid_object cimport GridLocation, GridObjectId, Orientation, GridObject
-from mettagrid.action cimport ActionHandler, ActionArg
 from mettagrid.actions.actions cimport MettaActionHandler
 from mettagrid.objects.metta_object cimport MettaObject
 from mettagrid.objects.constants cimport GridLayer

--- a/mettagrid/config/room/random.py
+++ b/mettagrid/config/room/random.py
@@ -19,6 +19,8 @@ class Random(Room):
     ):
         super().__init__(border_width=border_width, border_object=border_object)
         self._rng = np.random.default_rng(seed)
+        assert isinstance(width, int), f"width must be an int, got '{width}'"
+        assert isinstance(height, int), f"height must be an int, got {type(height)}"
         self._width = width
         self._height = height
         self._objects = objects

--- a/mettagrid/grid_env.pxd
+++ b/mettagrid/grid_env.pxd
@@ -3,7 +3,7 @@ import numpy as np
 
 from libcpp.string cimport string
 from libcpp.vector cimport vector
-from mettagrid.action cimport ActionHandler, Action
+from mettagrid.action_handler cimport ActionHandler
 from mettagrid.event cimport EventManager
 from mettagrid.grid_object cimport GridObjectId, GridObject
 from mettagrid.grid cimport Grid

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -5,8 +5,7 @@ import numpy as np
 cimport numpy as cnp
 import gymnasium as gym
 
-from mettagrid.action cimport ActionArg, ActionHandler
-from mettagrid.event cimport EventManager, EventHandler
+from mettagrid.action_handler cimport ActionArg, ActionHandler
 from mettagrid.grid cimport Grid
 from mettagrid.grid_object cimport (
     GridObject,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def build_ext(srcs, module_name=None):
 
 
 ext_modules = [
-    build_ext(["mettagrid/action.pyx"]),
+    build_ext(["mettagrid/action_handler.pyx"]),
     build_ext(["mettagrid/event.pyx"]),
     build_ext(["mettagrid/grid.cpp"]),
     build_ext(["mettagrid/grid_env.pyx"]),

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -54,7 +54,7 @@ def test_dependencies():
         "mettagrid.actions.noop",
         "mettagrid.actions.rotate",
         "mettagrid.actions.swap",
-        "mettagrid.action",
+        "mettagrid.action_handler",
         "mettagrid.event",
         "mettagrid.grid_env",
         "mettagrid.grid_object",


### PR DESCRIPTION
This is mostly a file rename, since having the files named differently than their main class is a pain. This also removes `Action` which is unused.

Directionally, this is towards getting rid of cython code.

Tested by compiling, and doing basic local training.