### PR TITLE
Rename actions -> metta_action_handler

### DIFF
--- a/mettagrid/actions/attack.pxd
+++ b/mettagrid/actions/attack.pxd
@@ -1,4 +1,5 @@
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 
 from mettagrid.grid_object cimport GridLocation
 from mettagrid.objects.agent cimport Agent

--- a/mettagrid/actions/attack.pyx
+++ b/mettagrid/actions/attack.pyx
@@ -3,7 +3,8 @@ from libc.stdio cimport printf
 from omegaconf import OmegaConf
 
 from mettagrid.action_handler cimport ActionArg
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 from mettagrid.grid_object cimport GridLocation, Orientation
 from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.constants cimport (

--- a/mettagrid/actions/change_color.pxd
+++ b/mettagrid/actions/change_color.pxd
@@ -1,6 +1,7 @@
 from mettagrid.action_handler cimport ActionArg
 from mettagrid.objects.agent cimport Agent
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 
 cdef class ChangeColorAction(MettaActionHandler):
     cdef unsigned char max_arg(self)

--- a/mettagrid/actions/change_color.pyx
+++ b/mettagrid/actions/change_color.pyx
@@ -3,7 +3,8 @@ from libc.stdio cimport printf
 from omegaconf import OmegaConf
 
 from mettagrid.action_handler cimport ActionArg
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 from mettagrid.objects.agent cimport Agent
 
 cdef class ChangeColorAction(MettaActionHandler):

--- a/mettagrid/actions/get_output.pxd
+++ b/mettagrid/actions/get_output.pxd
@@ -1,4 +1,5 @@
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 
 cdef class GetOutput(MettaActionHandler):
     pass

--- a/mettagrid/actions/get_output.pyx
+++ b/mettagrid/actions/get_output.pyx
@@ -7,7 +7,8 @@ from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.metta_object cimport MettaObject
 from mettagrid.objects.constants cimport Events, GridLayer, InventoryItem, InventoryItemNames
 from mettagrid.objects.converter cimport Converter
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 
 cdef class GetOutput(MettaActionHandler):
     def __init__(self, cfg: OmegaConf):

--- a/mettagrid/actions/metta_action_handler.pxd
+++ b/mettagrid/actions/metta_action_handler.pxd
@@ -1,4 +1,3 @@
-
 from libc.stdio cimport printf
 from libcpp.string cimport string
 from libcpp.map cimport map
@@ -30,4 +29,4 @@ cdef class MettaActionHandler(ActionHandler):
         self,
         unsigned int actor_id,
         Agent * actor,
-        ActionArg arg)
+        ActionArg arg) 

--- a/mettagrid/actions/metta_action_handler.pyx
+++ b/mettagrid/actions/metta_action_handler.pyx
@@ -54,4 +54,4 @@ cdef class MettaActionHandler(ActionHandler):
         unsigned int actor_id,
         Agent * actor,
         ActionArg arg):
-        return False
+        return False 

--- a/mettagrid/actions/move.pxd
+++ b/mettagrid/actions/move.pxd
@@ -1,4 +1,5 @@
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 
 cdef class Move(MettaActionHandler):
     pass

--- a/mettagrid/actions/move.pyx
+++ b/mettagrid/actions/move.pyx
@@ -3,7 +3,8 @@ from libc.stdio cimport printf
 from omegaconf import OmegaConf
 
 from mettagrid.action_handler cimport ActionArg
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 from mettagrid.grid_object cimport (
     GridLocation,
     GridObject,

--- a/mettagrid/actions/noop.pxd
+++ b/mettagrid/actions/noop.pxd
@@ -1,4 +1,5 @@
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 
 cdef class Noop(MettaActionHandler):
     pass

--- a/mettagrid/actions/noop.pyx
+++ b/mettagrid/actions/noop.pyx
@@ -3,7 +3,8 @@ from libc.stdio cimport printf
 from omegaconf import OmegaConf
 
 from mettagrid.action_handler cimport ActionArg
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 from mettagrid.objects.agent cimport Agent
 
 cdef class Noop(MettaActionHandler):

--- a/mettagrid/actions/put_recipe_items.pxd
+++ b/mettagrid/actions/put_recipe_items.pxd
@@ -1,4 +1,5 @@
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 
 cdef class PutRecipeItems(MettaActionHandler):
     pass

--- a/mettagrid/actions/put_recipe_items.pyx
+++ b/mettagrid/actions/put_recipe_items.pyx
@@ -7,7 +7,8 @@ from mettagrid.objects.agent cimport Agent
 from mettagrid.objects.metta_object cimport MettaObject
 from mettagrid.objects.constants cimport Events, GridLayer, InventoryItem, InventoryItemNames
 from mettagrid.objects.converter cimport Converter
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 
 # Puts one recipe worth of resources into a Converter. Noop if not enough resources.
 cdef class PutRecipeItems(MettaActionHandler):

--- a/mettagrid/actions/rotate.pxd
+++ b/mettagrid/actions/rotate.pxd
@@ -1,4 +1,5 @@
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 
 cdef class Rotate(MettaActionHandler):
     pass

--- a/mettagrid/actions/rotate.pyx
+++ b/mettagrid/actions/rotate.pyx
@@ -3,7 +3,8 @@ from libc.stdio cimport printf
 from omegaconf import OmegaConf
 
 from mettagrid.action_handler cimport ActionArg
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 from mettagrid.objects.agent cimport Agent
 
 cdef class Rotate(MettaActionHandler):

--- a/mettagrid/actions/swap.pxd
+++ b/mettagrid/actions/swap.pxd
@@ -1,4 +1,5 @@
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 
 cdef class Swap(MettaActionHandler):
     pass

--- a/mettagrid/actions/swap.pyx
+++ b/mettagrid/actions/swap.pyx
@@ -7,7 +7,8 @@ from mettagrid.grid_object cimport GridLocation, Orientation
 from mettagrid.action_handler cimport ActionArg
 from mettagrid.objects.agent cimport Agent
 from mettagrid.grid_object cimport GridLocation, GridObjectId, Orientation, GridObject
-from mettagrid.actions.actions cimport MettaActionHandler
+from mettagrid.actions.metta_action_handler cimport MettaActionHandler
+
 from mettagrid.objects.metta_object cimport MettaObject
 from mettagrid.objects.constants cimport GridLayer
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ ext_modules = [
     build_ext(["mettagrid/grid_object.pyx"]),
     build_ext(["mettagrid/stats_tracker.cpp"]),
     build_ext(["mettagrid/observation_encoder.pyx"]),
-    build_ext(["mettagrid/actions/actions.pyx"]),
+    build_ext(["mettagrid/actions/metta_action_handler.pyx"]),
     build_ext(["mettagrid/actions/attack.pyx"]),
     build_ext(["mettagrid/actions/attack_nearest.pyx"]),
     build_ext(["mettagrid/actions/change_color.pyx"]),


### PR DESCRIPTION
Renamed `actions.pyx/pxd` to `metta_action_handler.pyx/pxd` and updated all imports across the codebase, to make the filename match the class it defines. This is in service of cleaning up and removing the cython we have in our codebase.

Tested by compiling and doing basic training.