### PR TITLE
Move rewards from grid_env to agents

### DIFF
--- a/mettagrid/actions/attack.pyx
+++ b/mettagrid/actions/attack.pyx
@@ -35,7 +35,7 @@ cdef class Attack(MettaActionHandler):
         if actor.inventory[InventoryItem.laser] == 0:
             return False
 
-        actor.update_inventory(InventoryItem.laser, -1, &self.env._rewards[actor_id])
+        actor.update_inventory(InventoryItem.laser, -1)
 
         cdef short distance = 0
         cdef short offset = 0
@@ -73,7 +73,7 @@ cdef class Attack(MettaActionHandler):
             was_frozen = agent_target.frozen > 0
 
             if agent_target.inventory[InventoryItem.armor] > 0:
-                agent_target.update_inventory(InventoryItem.armor, -1, &self.env._rewards[agent_target.agent_id])
+                agent_target.update_inventory(InventoryItem.armor, -1)
                 actor.stats.incr(b"attack.blocked", agent_target.group_name)
                 actor.stats.incr(b"attack.blocked", agent_target.group_name, actor.group_name)
             else:
@@ -92,8 +92,8 @@ cdef class Attack(MettaActionHandler):
 
                     for item in range(InventoryItem.InventoryCount):
                         actor.stats.add(InventoryItemNames[item], b"stolen", actor.group_name, agent_target.inventory[item])
-                        actor.update_inventory(item, agent_target.inventory[item], &self.env._rewards[actor.agent_id])
-                        agent_target.update_inventory(item, -agent_target.inventory[item], &self.env._rewards[agent_target.agent_id])
+                        actor.update_inventory(item, agent_target.inventory[item])
+                        agent_target.update_inventory(item, -agent_target.inventory[item])
 
             return True
 

--- a/mettagrid/actions/attack_nearest.pyx
+++ b/mettagrid/actions/attack_nearest.pyx
@@ -29,7 +29,7 @@ cdef class AttackNearest(Attack):
         if actor.inventory[InventoryItem.laser] == 0:
             return False
 
-        actor.update_inventory(InventoryItem.laser, -1, &self.env._rewards[actor_id])
+        actor.update_inventory(InventoryItem.laser, -1)
 
         # Scan the space to find the nearest agent. Prefer the middle (offset 0) before the edges (offset -1, 1).
         for distance in range(1, 4):

--- a/mettagrid/actions/get_output.pyx
+++ b/mettagrid/actions/get_output.pyx
@@ -50,7 +50,7 @@ cdef class GetOutput(MettaActionHandler):
             # The actor will destroy anything it can't hold. That's not intentional, so feel free
             # to fix it.
             actor.stats.add(InventoryItemNames[i], b"get", converter.inventory[i])
-            actor.update_inventory(<InventoryItem>i, converter.inventory[i], &self.env._rewards[actor_id])
-            converter.update_inventory(<InventoryItem>i, -converter.inventory[i], NULL)
+            actor.update_inventory(<InventoryItem>i, converter.inventory[i])
+            converter.update_inventory(<InventoryItem>i, -converter.inventory[i])
 
         return True

--- a/mettagrid/actions/metta_action_handler.pyx
+++ b/mettagrid/actions/metta_action_handler.pyx
@@ -44,7 +44,7 @@ cdef class MettaActionHandler(ActionHandler):
         else:
             actor.stats.incr(self._stats.failure)
             actor.stats.incr(b"action.failure_penalty")
-            actor.reward[0] = actor.reward[0] + actor.action_failure_penalty
+            actor.reward[0] -= actor.action_failure_penalty
             actor.stats.set_once(self._stats.first_use, self.env._current_timestep)
 
         return result

--- a/mettagrid/actions/metta_action_handler.pyx
+++ b/mettagrid/actions/metta_action_handler.pyx
@@ -44,7 +44,7 @@ cdef class MettaActionHandler(ActionHandler):
         else:
             actor.stats.incr(self._stats.failure)
             actor.stats.incr(b"action.failure_penalty")
-            self.env._rewards[actor_id] -= actor.action_failure_penalty
+            actor.reward -= actor.action_failure_penalty
             actor.stats.set_once(self._stats.first_use, self.env._current_timestep)
 
         return result

--- a/mettagrid/actions/metta_action_handler.pyx
+++ b/mettagrid/actions/metta_action_handler.pyx
@@ -44,7 +44,7 @@ cdef class MettaActionHandler(ActionHandler):
         else:
             actor.stats.incr(self._stats.failure)
             actor.stats.incr(b"action.failure_penalty")
-            actor.reward -= actor.action_failure_penalty
+            actor.reward[0] = actor.reward[0] + actor.action_failure_penalty
             actor.stats.set_once(self._stats.first_use, self.env._current_timestep)
 
         return result

--- a/mettagrid/actions/put_recipe_items.pyx
+++ b/mettagrid/actions/put_recipe_items.pyx
@@ -41,8 +41,8 @@ cdef class PutRecipeItems(MettaActionHandler):
                 return False
 
         for i in range(converter.recipe_input.size()):
-            actor.update_inventory(<InventoryItem>i, -converter.recipe_input[i], &self.env._rewards[actor_id])
-            converter.update_inventory(<InventoryItem>i, converter.recipe_input[i], NULL)
+            actor.update_inventory(<InventoryItem>i, -converter.recipe_input[i])
+            converter.update_inventory(<InventoryItem>i, converter.recipe_input[i])
             actor.stats.add(InventoryItemNames[i], b"put", converter.recipe_input[i]);
 
         return True

--- a/mettagrid/grid_env.pxd
+++ b/mettagrid/grid_env.pxd
@@ -109,5 +109,6 @@ cdef class GridEnv:
     cpdef dict get_episode_stats(self)
     cpdef get_episode_rewards(self)
 
+    cpdef tuple get_buffers(self)
     cpdef cnp.ndarray render_ascii(self)
     cpdef cnp.ndarray grid_objects_types(self)

--- a/mettagrid/grid_env.pxd
+++ b/mettagrid/grid_env.pxd
@@ -9,6 +9,7 @@ from mettagrid.grid_object cimport GridObjectId, GridObject
 from mettagrid.grid cimport Grid
 from mettagrid.observation_encoder cimport ObservationEncoder, ObsType
 from mettagrid.stats_tracker cimport StatsTracker
+from mettagrid.objects.agent cimport Agent
 
 ctypedef unsigned int ActionType
 
@@ -33,7 +34,7 @@ cdef class GridEnv:
         unsigned short _middle_x
         unsigned short _middle_y
 
-        vector[GridObject*] _agents
+        vector[Agent*] _agents
 
         cnp.ndarray _observations_np
         ObsType[:,:,:,:] _observations
@@ -53,7 +54,7 @@ cdef class GridEnv:
         unsigned char _last_action_arg_obs_idx
         vector[bint] _action_success
 
-    cdef void add_agent(self, GridObject* agent)
+    cdef void add_agent(self, Agent* agent)
 
     cdef void _compute_observations(self, int[:,:] actions)
     cdef void _step(self, int[:,:] actions)
@@ -108,6 +109,5 @@ cdef class GridEnv:
     cpdef dict get_episode_stats(self)
     cpdef get_episode_rewards(self)
 
-    cpdef tuple get_buffers(self)
     cpdef cnp.ndarray render_ascii(self)
     cpdef cnp.ndarray grid_objects_types(self)

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -13,10 +13,10 @@ from mettagrid.grid_object cimport (
     Layer,
     GridLocation
 )
+from mettagrid.objects.agent cimport Agent
 from mettagrid.observation_encoder cimport ObservationEncoder, ObsType
 from mettagrid.objects.production_handler cimport ProductionHandler, CoolDownHandler
 from mettagrid.objects.constants cimport ObjectTypeNames, ObjectTypeAscii
-from mettagrid.objects.agent cimport Agent
 
 # Constants
 obs_np_type = np.uint8
@@ -91,6 +91,7 @@ cdef class GridEnv:
         del self._grid
 
     cdef void add_agent(self, Agent* agent):
+        agent.init(&self._rewards[self._agents.size()])
         self._agents.push_back(agent)
 
     cdef void _compute_observation(
@@ -152,8 +153,7 @@ cdef class GridEnv:
             Agent *agent
             ActionHandler handler
 
-        for agent in self._agents:
-            agent.reward = 0
+        self._rewards[:] = 0
         self._observations[:, :, :, :] = 0
 
         self._current_timestep += 1
@@ -179,7 +179,7 @@ cdef class GridEnv:
         self._compute_observations(actions)
 
         for i in range(self._episode_rewards.shape[0]):
-            self._episode_rewards[i] += self._agents[i].reward
+            self._episode_rewards[i] += self._rewards[i]
 
         if self._max_timestep > 0 and self._current_timestep >= self._max_timestep:
             self._truncations[:] = 1
@@ -195,26 +195,21 @@ cdef class GridEnv:
         self._truncations[:] = 0
         self._episode_rewards[:] = 0
         self._observations[:, :, :, :] = 0
-        # Maybe not needed, but left over from when reward was on the grid.
-        for agent in self._agents:
-            agent.reward = 0
+        self._rewards[:] = 0
 
         self._compute_observations(np.zeros((self._agents.size(), 2), dtype=np.int32))
         return (self._observations_np, {})
 
     cpdef tuple[cnp.ndarray, cnp.ndarray, cnp.ndarray, cnp.ndarray, dict] step(self, cnp.ndarray actions):
         self._step(actions)
-        rewards_np = np.zeros(self._agents.size(), dtype=np.float32)
-        for i in range(self._agents.size()):
-            rewards_np[i] = self._agents[i].reward
-        return (self._observations_np, rewards_np, self._terminals_np, self._truncations_np, {})
+        return (self._observations_np, self._rewards_np, self._terminals_np, self._truncations_np, {})
 
     cpdef void set_buffers(
         self,
         cnp.ndarray[ObsType, ndim=4] observations,
         cnp.ndarray[char, ndim=1] terminals,
         cnp.ndarray[char, ndim=1] truncations,
-        cnp.ndarray[float, ndim=1] episode_rewards):
+        cnp.ndarray[float, ndim=1] rewards):
 
         self._observations_np = observations
         self._observations = observations
@@ -222,8 +217,13 @@ cdef class GridEnv:
         self._terminals = terminals
         self._truncations_np = truncations
         self._truncations = truncations
-        self._episode_rewards_np = episode_rewards
-        self._episode_rewards = episode_rewards
+        self._rewards_np = rewards
+        self._rewards = rewards
+        self._episode_rewards_np = np.zeros_like(rewards)
+        self._episode_rewards = self._episode_rewards_np
+
+        for i in range(self._agents.size()):
+            self._agents[i].init(&self._rewards[i])
 
     cpdef grid(self):
         return []
@@ -278,6 +278,9 @@ cdef class GridEnv:
         return {
             "game": self._stats.stats(),
         }
+
+    cpdef tuple get_buffers(self):
+        return (self._observations_np, self._terminals_np, self._truncations_np, self._rewards_np)
 
     cpdef cnp.ndarray render_ascii(self):
         cdef GridObject *obj

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -16,6 +16,7 @@ from mettagrid.grid_object cimport (
 from mettagrid.observation_encoder cimport ObservationEncoder, ObsType
 from mettagrid.objects.production_handler cimport ProductionHandler, CoolDownHandler
 from mettagrid.objects.constants cimport ObjectTypeNames, ObjectTypeAscii
+from mettagrid.objects.agent cimport Agent
 
 # Constants
 obs_np_type = np.uint8
@@ -89,7 +90,7 @@ cdef class GridEnv:
     def __dealloc__(self):
         del self._grid
 
-    cdef void add_agent(self, GridObject* agent):
+    cdef void add_agent(self, Agent* agent):
         self._agents.push_back(agent)
 
     cdef void _compute_observation(
@@ -127,7 +128,7 @@ cdef class GridEnv:
                     self._obs_encoder.encode(obj, agent_ob)
 
     cdef void _compute_observations(self, int[:,:] actions):
-        cdef GridObject *agent
+        cdef Agent *agent
         for idx in range(self._agents.size()):
             agent = self._agents[idx]
             self._compute_observation(
@@ -148,10 +149,11 @@ cdef class GridEnv:
             unsigned int idx
             short action
             ActionArg arg
-            GridObject *agent
+            Agent *agent
             ActionHandler handler
 
-        self._rewards[:] = 0
+        for agent in self._agents:
+            agent.reward = 0
         self._observations[:, :, :, :] = 0
 
         self._current_timestep += 1
@@ -177,7 +179,7 @@ cdef class GridEnv:
         self._compute_observations(actions)
 
         for i in range(self._episode_rewards.shape[0]):
-            self._episode_rewards[i] += self._rewards[i]
+            self._episode_rewards[i] += self._agents[i].reward
 
         if self._max_timestep > 0 and self._current_timestep >= self._max_timestep:
             self._truncations[:] = 1
@@ -193,21 +195,26 @@ cdef class GridEnv:
         self._truncations[:] = 0
         self._episode_rewards[:] = 0
         self._observations[:, :, :, :] = 0
-        self._rewards[:] = 0
+        # Maybe not needed, but left over from when reward was on the grid.        
+        for agent in self._agents:
+            agent.reward = 0
 
         self._compute_observations(np.zeros((self._agents.size(), 2), dtype=np.int32))
         return (self._observations_np, {})
 
     cpdef tuple[cnp.ndarray, cnp.ndarray, cnp.ndarray, cnp.ndarray, dict] step(self, cnp.ndarray actions):
         self._step(actions)
-        return (self._observations_np, self._rewards_np, self._terminals_np, self._truncations_np, {})
+        rewards_np = np.zeros(self._agents.size(), dtype=np.float32)
+        for i in range(self._agents.size()):
+            rewards_np[i] = self._agents[i].reward
+        return (self._observations_np, rewards_np, self._terminals_np, self._truncations_np, {})
 
     cpdef void set_buffers(
         self,
         cnp.ndarray[ObsType, ndim=4] observations,
         cnp.ndarray[char, ndim=1] terminals,
         cnp.ndarray[char, ndim=1] truncations,
-        cnp.ndarray[float, ndim=1] rewards):
+        cnp.ndarray[float, ndim=1] episode_rewards):
 
         self._observations_np = observations
         self._observations = observations
@@ -215,10 +222,8 @@ cdef class GridEnv:
         self._terminals = terminals
         self._truncations_np = truncations
         self._truncations = truncations
-        self._rewards_np = rewards
-        self._rewards = rewards
-        self._episode_rewards_np = np.zeros_like(rewards)
-        self._episode_rewards = self._episode_rewards_np
+        self._episode_rewards_np = episode_rewards
+        self._episode_rewards = episode_rewards
 
     cpdef grid(self):
         return []
@@ -273,9 +278,6 @@ cdef class GridEnv:
         return {
             "game": self._stats.stats(),
         }
-
-    cpdef tuple get_buffers(self):
-        return (self._observations_np, self._terminals_np, self._truncations_np, self._rewards_np)
 
     cpdef cnp.ndarray render_ascii(self):
         cdef GridObject *obj

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -195,7 +195,7 @@ cdef class GridEnv:
         self._truncations[:] = 0
         self._episode_rewards[:] = 0
         self._observations[:, :, :, :] = 0
-        # Maybe not needed, but left over from when reward was on the grid.        
+        # Maybe not needed, but left over from when reward was on the grid.
         for agent in self._agents:
             agent.reward = 0
 

--- a/mettagrid/objects/agent.hpp
+++ b/mettagrid/objects/agent.hpp
@@ -25,7 +25,7 @@ public:
     StatsTracker stats;
     float current_resource_reward;
     // Accumulated reward for the agent.
-    float reward;
+    float *reward;
 
     Agent(
         GridCoord r, GridCoord c,
@@ -56,7 +56,11 @@ public:
         this->action_failure_penalty = rewards["action_failure_penalty"];
         this->color = 0;
         this->current_resource_reward = 0;
-        this->reward = 0;
+        this->reward = nullptr;
+    }
+
+    void init(float *reward) {
+        this->reward = reward;
     }
 
     void update_inventory(InventoryItem item, short amount) {
@@ -94,7 +98,7 @@ public:
             }
             new_reward += this->resource_rewards[i] * max_val;
         }
-        this->reward += (new_reward - this->current_resource_reward);
+        *this->reward += (new_reward - this->current_resource_reward);
         this->current_resource_reward = new_reward;
     }
 

--- a/mettagrid/objects/agent.hpp
+++ b/mettagrid/objects/agent.hpp
@@ -24,12 +24,16 @@ public:
     unsigned char agent_id;
     StatsTracker stats;
     float current_resource_reward;
+    // Accumulated reward for the agent.
+    float reward;
 
     Agent(
         GridCoord r, GridCoord c,
         std::string group_name,
         unsigned char group_id,
         ObjectConfig cfg,
+        // Configuration -- rewards that the agent will get for certain
+        // actions or inventory changes.
         std::map<std::string, float> rewards) {
         GridObject::init(ObjectType::AgentT, GridLocation(r, c, GridLayer::Agent_Layer));
         MettaObject::init_mo(cfg);
@@ -52,9 +56,10 @@ public:
         this->action_failure_penalty = rewards["action_failure_penalty"];
         this->color = 0;
         this->current_resource_reward = 0;
+        this->reward = 0;
     }
 
-    void update_inventory(InventoryItem item, short amount, float *reward) {
+    void update_inventory(InventoryItem item, short amount) {
         int current_amount = this->inventory[static_cast<int>(item)];
         int new_amount = current_amount + amount;
         if (new_amount > this->max_items) {
@@ -73,10 +78,10 @@ public:
             this->stats.add(InventoryItemNames[item], "lost", -delta);
         }
 
-        this->compute_resource_reward(item, reward);
+        this->compute_resource_reward(item);
     }
 
-    inline void compute_resource_reward(InventoryItem item, float *reward) {
+    inline void compute_resource_reward(InventoryItem item) {
         if (this->resource_rewards[static_cast<int>(item)] == 0) {
             return;
         }
@@ -89,7 +94,7 @@ public:
             }
             new_reward += this->resource_rewards[i] * max_val;
         }
-        *reward += (new_reward - this->current_resource_reward);
+        this->reward += (new_reward - this->current_resource_reward);
         this->current_resource_reward = new_reward;
     }
 

--- a/mettagrid/objects/agent.hpp
+++ b/mettagrid/objects/agent.hpp
@@ -24,7 +24,6 @@ public:
     unsigned char agent_id;
     StatsTracker stats;
     float current_resource_reward;
-    // Accumulated reward for the agent.
     float *reward;
 
     Agent(

--- a/mettagrid/objects/agent.pxd
+++ b/mettagrid/objects/agent.pxd
@@ -21,6 +21,8 @@ cdef extern from "agent.hpp":
         unsigned char color
         unsigned char agent_id
         StatsTracker stats
+        # This should reference the reward buffer in the GridEnv, which
+        # accumulates rewards for all agents on a per-step basis.
         float *reward
 
         Agent(GridCoord r, GridCoord c,

--- a/mettagrid/objects/agent.pxd
+++ b/mettagrid/objects/agent.pxd
@@ -21,6 +21,7 @@ cdef extern from "agent.hpp":
         unsigned char color
         unsigned char agent_id
         StatsTracker stats
+        float reward
 
         Agent(GridCoord r, GridCoord c,
             string group_name,
@@ -28,7 +29,7 @@ cdef extern from "agent.hpp":
             ObjectConfig cfg,
             map[string, float] rewards)
 
-        void update_inventory(InventoryItem item, short amount, float *reward)
+        void update_inventory(InventoryItem item, short amount)
 
         @staticmethod
         inline vector[string] feature_names()

--- a/mettagrid/objects/agent.pxd
+++ b/mettagrid/objects/agent.pxd
@@ -21,7 +21,7 @@ cdef extern from "agent.hpp":
         unsigned char color
         unsigned char agent_id
         StatsTracker stats
-        float reward
+        float *reward
 
         Agent(GridCoord r, GridCoord c,
             string group_name,
@@ -30,6 +30,11 @@ cdef extern from "agent.hpp":
             map[string, float] rewards)
 
         void update_inventory(InventoryItem item, short amount)
+
+        # This is used to link the agent's reward to the grid's rewards.
+        # It's valid to call this multiple times, if you need to re-link the
+        # reward.
+        void init(float *reward)
 
         @staticmethod
         inline vector[string] feature_names()

--- a/mettagrid/objects/converter.hpp
+++ b/mettagrid/objects/converter.hpp
@@ -87,7 +87,7 @@ public:
         unsigned char initial_items = cfg["initial_items"];
         for (unsigned int i = 0; i < InventoryItem::InventoryCount; i++) {
             if (this->recipe_output[i] > 0) {
-                HasInventory::update_inventory(static_cast<InventoryItem>(i), initial_items, nullptr);
+                HasInventory::update_inventory(static_cast<InventoryItem>(i), initial_items);
             }
         }
     }
@@ -105,7 +105,7 @@ public:
         // Add output to inventory
         for (unsigned int i = 0; i < InventoryItem::InventoryCount; i++) {
             if (this->recipe_output[i] > 0) {
-                HasInventory::update_inventory(static_cast<InventoryItem>(i), this->recipe_output[i], nullptr);
+                HasInventory::update_inventory(static_cast<InventoryItem>(i), this->recipe_output[i]);
             }
         }
 
@@ -129,8 +129,8 @@ public:
         this->maybe_start_converting();
     }
 
-    void update_inventory(InventoryItem item, short amount, float *reward) override {
-        HasInventory::update_inventory(item, amount, reward);
+    void update_inventory(InventoryItem item, short amount) override {
+        HasInventory::update_inventory(item, amount);
         this->maybe_start_converting();
     }
 

--- a/mettagrid/objects/has_inventory.hpp
+++ b/mettagrid/objects/has_inventory.hpp
@@ -23,7 +23,7 @@ public:
         return true;
     }
 
-    virtual void update_inventory(InventoryItem item, short amount, float *reward) {
+    virtual void update_inventory(InventoryItem item, short amount) {
         if (amount + this->inventory[item] > 255) {
             amount = 255 - this->inventory[item];
         }

--- a/mettagrid/objects/has_inventory.pxd
+++ b/mettagrid/objects/has_inventory.pxd
@@ -8,5 +8,5 @@ cdef extern from "has_inventory.hpp":
         void init_has_inventory(ObjectConfig cfg)
         bint has_inventory()
         bint inventory_is_accessible()
-        void update_inventory(InventoryItem item, unsigned char amount, float *reward)
+        void update_inventory(InventoryItem item, unsigned char amount)
 


### PR DESCRIPTION
This moves reward -- at least the single-step accumulation of reward -- to agents. This move reduces the dependency of actions on grid_env. Once that dependency is gone, we can convert actions out of cython.

This also mostly feels cleaner.

Test:
Ran some benchmark perf tests to make sure something wasn't obviously off about this: `python deps/mettagrid/tests/benchmark_env_perf.py`