### PR TITLE
Remove the dependency from actions to GridEnv

### DIFF
--- a/mettagrid/action_handler.pxd
+++ b/mettagrid/action_handler.pxd
@@ -1,15 +1,15 @@
 from mettagrid.grid_object cimport GridObjectId
-from mettagrid.grid_env cimport GridEnv
+from mettagrid.grid cimport Grid
 from libcpp.string cimport string
 
 ctypedef unsigned int ActionArg
 
 cdef class ActionHandler:
-    cdef GridEnv env
+    cdef Grid *_grid
     cdef string _action_name
     cdef unsigned char _priority
 
-    cdef void init(self, GridEnv env)
+    cdef void init(self, Grid *grid)
 
     cdef bint handle_action(
         self,

--- a/mettagrid/action_handler.pxd
+++ b/mettagrid/action_handler.pxd
@@ -15,7 +15,8 @@ cdef class ActionHandler:
         self,
         unsigned int actor_id,
         GridObjectId actor_object_id,
-        ActionArg arg)
+        ActionArg arg,
+        unsigned int current_timestep)
 
     cdef unsigned char max_arg(self)
 

--- a/mettagrid/action_handler.pyx
+++ b/mettagrid/action_handler.pyx
@@ -14,7 +14,8 @@ cdef class ActionHandler:
         self,
         unsigned int actor_id,
         GridObjectId actor_object_id,
-        ActionArg arg):
+        ActionArg arg,
+        unsigned int current_timestep):
         return False
 
     cdef unsigned char max_arg(self):

--- a/mettagrid/action_handler.pyx
+++ b/mettagrid/action_handler.pyx
@@ -1,5 +1,5 @@
 from mettagrid.action_handler cimport ActionArg
-from mettagrid.grid_env cimport GridEnv
+from mettagrid.grid cimport Grid
 from mettagrid.grid_object cimport GridObjectId
 
 cdef class ActionHandler:
@@ -7,8 +7,8 @@ cdef class ActionHandler:
         self._action_name = action_name
         self._priority = 0
 
-    cdef void init(self, GridEnv env):
-        self.env = env
+    cdef void init(self, Grid *grid):
+        self._grid = grid
 
     cdef bint handle_action(
         self,

--- a/mettagrid/actions/attack.pyx
+++ b/mettagrid/actions/attack.pyx
@@ -42,7 +42,7 @@ cdef class Attack(MettaActionHandler):
         distance = 1 + (arg - 1) // 3
         offset = -((arg - 1) % 3 - 1)
 
-        cdef GridLocation target_loc = self.env._grid.relative_location(
+        cdef GridLocation target_loc = self._grid.relative_location(
             actor.location,
             <Orientation>actor.orientation,
             distance, offset)
@@ -57,7 +57,7 @@ cdef class Attack(MettaActionHandler):
 
         target_loc.layer = GridLayer.Agent_Layer
         # Because we're looking on the agent layer, we can cast to Agent.
-        cdef Agent * agent_target = <Agent *>self.env._grid.object_at(target_loc)
+        cdef Agent * agent_target = <Agent *>self._grid.object_at(target_loc)
 
         cdef bint was_frozen = False
         if agent_target:
@@ -98,14 +98,14 @@ cdef class Attack(MettaActionHandler):
             return True
 
         target_loc.layer = GridLayer.Object_Layer
-        cdef MettaObject * object_target = <MettaObject *>self.env._grid.object_at(target_loc)
+        cdef MettaObject * object_target = <MettaObject *>self._grid.object_at(target_loc)
         if object_target:
             actor.stats.incr(self._stats.target[object_target._type_id])
             actor.stats.incr(self._stats.target[object_target._type_id], actor.group_name)
             object_target.hp -= 1
             actor.stats.incr(b"damage", ObjectTypeNames[object_target._type_id])
             if object_target.hp <= 0:
-                self.env._grid.remove_object(object_target)
+                self._grid.remove_object(object_target)
                 actor.stats.incr(b"destroyed", ObjectTypeNames[object_target._type_id])
             return True
 

--- a/mettagrid/actions/attack_nearest.pyx
+++ b/mettagrid/actions/attack_nearest.pyx
@@ -37,13 +37,13 @@ cdef class AttackNearest(Attack):
                 if offset == 2:
                     # Sort of a mod 3 operation.
                     offset = -1
-                target_loc = self.env._grid.relative_location(
+                target_loc = self._grid.relative_location(
                     actor.location,
                     <Orientation>actor.orientation,
                     distance, offset)
 
                 target_loc.layer = GridLayer.Agent_Layer
-                agent_target = <Agent *>self.env._grid.object_at(target_loc)
+                agent_target = <Agent *>self._grid.object_at(target_loc)
                 if agent_target:
                     return self._handle_target(actor_id, actor, target_loc)
 

--- a/mettagrid/actions/get_output.pyx
+++ b/mettagrid/actions/get_output.pyx
@@ -23,12 +23,12 @@ cdef class GetOutput(MettaActionHandler):
         Agent * actor,
         ActionArg arg):
 
-        cdef GridLocation target_loc = self.env._grid.relative_location(
+        cdef GridLocation target_loc = self._grid.relative_location(
             actor.location,
             <Orientation>actor.orientation
         )
         target_loc.layer = GridLayer.Object_Layer
-        cdef MettaObject *target = <MettaObject*>self.env._grid.object_at(target_loc)
+        cdef MettaObject *target = <MettaObject*>self._grid.object_at(target_loc)
         if target == NULL or not target.has_inventory():
             return False
 

--- a/mettagrid/actions/metta_action_handler.pxd
+++ b/mettagrid/actions/metta_action_handler.pxd
@@ -23,7 +23,8 @@ cdef class MettaActionHandler(ActionHandler):
         self,
         unsigned int actor_id,
         GridObjectId actor_object_id,
-        ActionArg arg)
+        ActionArg arg,
+        unsigned int current_timestep)
 
     cdef bint _handle_action(
         self,

--- a/mettagrid/actions/metta_action_handler.pyx
+++ b/mettagrid/actions/metta_action_handler.pyx
@@ -29,7 +29,7 @@ cdef class MettaActionHandler(ActionHandler):
         GridObjectId actor_object_id,
         ActionArg arg):
 
-        cdef Agent *actor = <Agent*>self.env._grid.object(actor_object_id)
+        cdef Agent *actor = <Agent*>self._grid.object(actor_object_id)
 
         if actor.frozen > 0:
             actor.stats.incr(b"status.frozen.ticks")
@@ -45,7 +45,7 @@ cdef class MettaActionHandler(ActionHandler):
             actor.stats.incr(self._stats.failure)
             actor.stats.incr(b"action.failure_penalty")
             actor.reward[0] -= actor.action_failure_penalty
-            actor.stats.set_once(self._stats.first_use, self.env._current_timestep)
+            actor.stats.set_once(self._stats.first_use, self._current_timestep)
 
         return result
 

--- a/mettagrid/actions/metta_action_handler.pyx
+++ b/mettagrid/actions/metta_action_handler.pyx
@@ -27,7 +27,8 @@ cdef class MettaActionHandler(ActionHandler):
         self,
         unsigned int actor_id,
         GridObjectId actor_object_id,
-        ActionArg arg):
+        ActionArg arg,
+        unsigned int current_timestep):
 
         cdef Agent *actor = <Agent*>self._grid.object(actor_object_id)
 
@@ -45,7 +46,7 @@ cdef class MettaActionHandler(ActionHandler):
             actor.stats.incr(self._stats.failure)
             actor.stats.incr(b"action.failure_penalty")
             actor.reward[0] -= actor.action_failure_penalty
-            actor.stats.set_once(self._stats.first_use, self._current_timestep)
+            actor.stats.set_once(self._stats.first_use, current_timestep)
 
         return result
 

--- a/mettagrid/actions/move.pyx
+++ b/mettagrid/actions/move.pyx
@@ -40,7 +40,7 @@ cdef class Move(MettaActionHandler):
                 orientation = Orientation.Left
 
         cdef GridLocation old_loc = actor.location
-        cdef GridLocation new_loc = self.env._grid.relative_location(old_loc, orientation)
-        if not self.env._grid.is_empty(new_loc.r, new_loc.c):
+        cdef GridLocation new_loc = self._grid.relative_location(old_loc, orientation)
+        if not self._grid.is_empty(new_loc.r, new_loc.c):
             return 0
-        return self.env._grid.move_object(actor.id, new_loc)
+        return self._grid.move_object(actor.id, new_loc)

--- a/mettagrid/actions/put_recipe_items.pyx
+++ b/mettagrid/actions/put_recipe_items.pyx
@@ -24,12 +24,12 @@ cdef class PutRecipeItems(MettaActionHandler):
         Agent * actor,
         ActionArg arg):
 
-        cdef GridLocation target_loc = self.env._grid.relative_location(
+        cdef GridLocation target_loc = self._grid.relative_location(
             actor.location,
             <Orientation>actor.orientation
         )
         target_loc.layer = GridLayer.Object_Layer
-        cdef MettaObject *target = <MettaObject*>self.env._grid.object_at(target_loc)
+        cdef MettaObject *target = <MettaObject*>self._grid.object_at(target_loc)
         if target == NULL or not target.has_inventory():
             return False
 

--- a/mettagrid/actions/swap.pyx
+++ b/mettagrid/actions/swap.pyx
@@ -25,15 +25,15 @@ cdef class Swap(MettaActionHandler):
         Agent * actor,
         ActionArg arg):
 
-        cdef GridLocation target_loc = self.env._grid.relative_location(
+        cdef GridLocation target_loc = self._grid.relative_location(
             actor.location,
             <Orientation>actor.orientation
         )
         cdef MettaObject *target
-        target = <MettaObject*>self.env._grid.object_at(target_loc)
+        target = <MettaObject*>self._grid.object_at(target_loc)
         if target == NULL:
             target_loc.layer = GridLayer.Object_Layer
-            target = <MettaObject*>self.env._grid.object_at(target_loc)
+            target = <MettaObject*>self._grid.object_at(target_loc)
         if target == NULL:
             return False
 
@@ -42,5 +42,5 @@ cdef class Swap(MettaActionHandler):
 
         actor.stats.incr(b"swap", self._stats.target[target._type_id])
 
-        self.env._grid.swap_objects(actor.id, target.id)
+        self._grid.swap_objects(actor.id, target.id)
         return True

--- a/mettagrid/grid_env.pxd
+++ b/mettagrid/grid_env.pxd
@@ -109,6 +109,5 @@ cdef class GridEnv:
     cpdef dict get_episode_stats(self)
     cpdef get_episode_rewards(self)
 
-    cpdef tuple get_buffers(self)
     cpdef cnp.ndarray render_ascii(self)
     cpdef cnp.ndarray grid_objects_types(self)

--- a/mettagrid/grid_env.pxd
+++ b/mettagrid/grid_env.pxd
@@ -109,5 +109,6 @@ cdef class GridEnv:
     cpdef dict get_episode_stats(self)
     cpdef get_episode_rewards(self)
 
+    cpdef tuple get_buffers(self)
     cpdef cnp.ndarray render_ascii(self)
     cpdef cnp.ndarray grid_objects_types(self)

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -17,7 +17,6 @@ from mettagrid.objects.agent cimport Agent
 from mettagrid.observation_encoder cimport ObservationEncoder, ObsType
 from mettagrid.objects.production_handler cimport ProductionHandler, CoolDownHandler
 from mettagrid.objects.constants cimport ObjectTypeNames, ObjectTypeAscii
-from mettagrid.objects.agent cimport Agent
 
 # Constants
 obs_np_type = np.uint8
@@ -154,8 +153,7 @@ cdef class GridEnv:
             Agent *agent
             ActionHandler handler
 
-        for agent in self._agents:
-            agent.reward = 0
+        self._rewards[:] = 0
         self._observations[:, :, :, :] = 0
 
         self._current_timestep += 1
@@ -181,7 +179,7 @@ cdef class GridEnv:
         self._compute_observations(actions)
 
         for i in range(self._episode_rewards.shape[0]):
-            self._episode_rewards[i] += self._agents[i].reward
+            self._episode_rewards[i] += self._rewards[i]
 
         if self._max_timestep > 0 and self._current_timestep >= self._max_timestep:
             self._truncations[:] = 1
@@ -197,26 +195,21 @@ cdef class GridEnv:
         self._truncations[:] = 0
         self._episode_rewards[:] = 0
         self._observations[:, :, :, :] = 0
-        # Maybe not needed, but left over from when reward was on the grid.
-        for agent in self._agents:
-            agent.reward = 0
+        self._rewards[:] = 0
 
         self._compute_observations(np.zeros((self._agents.size(), 2), dtype=np.int32))
         return (self._observations_np, {})
 
     cpdef tuple[cnp.ndarray, cnp.ndarray, cnp.ndarray, cnp.ndarray, dict] step(self, cnp.ndarray actions):
         self._step(actions)
-        rewards_np = np.zeros(self._agents.size(), dtype=np.float32)
-        for i in range(self._agents.size()):
-            rewards_np[i] = self._agents[i].reward
-        return (self._observations_np, rewards_np, self._terminals_np, self._truncations_np, {})
+        return (self._observations_np, self._rewards_np, self._terminals_np, self._truncations_np, {})
 
     cpdef void set_buffers(
         self,
         cnp.ndarray[ObsType, ndim=4] observations,
         cnp.ndarray[char, ndim=1] terminals,
         cnp.ndarray[char, ndim=1] truncations,
-        cnp.ndarray[float, ndim=1] episode_rewards):
+        cnp.ndarray[float, ndim=1] rewards):
 
         self._observations_np = observations
         self._observations = observations
@@ -224,8 +217,13 @@ cdef class GridEnv:
         self._terminals = terminals
         self._truncations_np = truncations
         self._truncations = truncations
-        self._episode_rewards_np = episode_rewards
-        self._episode_rewards = episode_rewards
+        self._rewards_np = rewards
+        self._rewards = rewards
+        self._episode_rewards_np = np.zeros_like(rewards)
+        self._episode_rewards = self._episode_rewards_np
+
+        for i in range(self._agents.size()):
+            self._agents[i].init(&self._rewards[i])
 
         for i in range(self._agents.size()):
             self._agents[i].init(&self._rewards[i])
@@ -283,6 +281,9 @@ cdef class GridEnv:
         return {
             "game": self._stats.stats(),
         }
+
+    cpdef tuple get_buffers(self):
+        return (self._observations_np, self._terminals_np, self._truncations_np, self._rewards_np)
 
     cpdef cnp.ndarray render_ascii(self):
         cdef GridObject *obj

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -174,7 +174,7 @@ cdef class GridEnv:
                     continue
                 if arg > self._max_action_args[action]:
                     continue
-                self._action_success[idx] = handler.handle_action(idx, agent.id, arg)
+                self._action_success[idx] = handler.handle_action(idx, agent.id, arg, self._current_timestep)
 
         self._compute_observations(actions)
 

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -58,7 +58,7 @@ cdef class GridEnv:
         self._max_action_arg = 0
         self._max_action_args.resize(len(action_handlers))
         for i, handler in enumerate(action_handlers):
-            (<ActionHandler>handler).init(self)
+            (<ActionHandler>handler).init(self._grid)
             max_arg = (<ActionHandler>handler).max_arg()
             self._max_action_args[i] = max_arg
             self._max_action_arg = max(self._max_action_arg, max_arg)

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -225,9 +225,6 @@ cdef class GridEnv:
         for i in range(self._agents.size()):
             self._agents[i].init(&self._rewards[i])
 
-        for i in range(self._agents.size()):
-            self._agents[i].init(&self._rewards[i])
-
     cpdef grid(self):
         return []
 

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -17,6 +17,7 @@ from mettagrid.objects.agent cimport Agent
 from mettagrid.observation_encoder cimport ObservationEncoder, ObsType
 from mettagrid.objects.production_handler cimport ProductionHandler, CoolDownHandler
 from mettagrid.objects.constants cimport ObjectTypeNames, ObjectTypeAscii
+from mettagrid.objects.agent cimport Agent
 
 # Constants
 obs_np_type = np.uint8
@@ -153,7 +154,8 @@ cdef class GridEnv:
             Agent *agent
             ActionHandler handler
 
-        self._rewards[:] = 0
+        for agent in self._agents:
+            agent.reward = 0
         self._observations[:, :, :, :] = 0
 
         self._current_timestep += 1
@@ -179,7 +181,7 @@ cdef class GridEnv:
         self._compute_observations(actions)
 
         for i in range(self._episode_rewards.shape[0]):
-            self._episode_rewards[i] += self._rewards[i]
+            self._episode_rewards[i] += self._agents[i].reward
 
         if self._max_timestep > 0 and self._current_timestep >= self._max_timestep:
             self._truncations[:] = 1
@@ -195,21 +197,26 @@ cdef class GridEnv:
         self._truncations[:] = 0
         self._episode_rewards[:] = 0
         self._observations[:, :, :, :] = 0
-        self._rewards[:] = 0
+        # Maybe not needed, but left over from when reward was on the grid.        
+        for agent in self._agents:
+            agent.reward = 0
 
         self._compute_observations(np.zeros((self._agents.size(), 2), dtype=np.int32))
         return (self._observations_np, {})
 
     cpdef tuple[cnp.ndarray, cnp.ndarray, cnp.ndarray, cnp.ndarray, dict] step(self, cnp.ndarray actions):
         self._step(actions)
-        return (self._observations_np, self._rewards_np, self._terminals_np, self._truncations_np, {})
+        rewards_np = np.zeros(self._agents.size(), dtype=np.float32)
+        for i in range(self._agents.size()):
+            rewards_np[i] = self._agents[i].reward
+        return (self._observations_np, rewards_np, self._terminals_np, self._truncations_np, {})
 
     cpdef void set_buffers(
         self,
         cnp.ndarray[ObsType, ndim=4] observations,
         cnp.ndarray[char, ndim=1] terminals,
         cnp.ndarray[char, ndim=1] truncations,
-        cnp.ndarray[float, ndim=1] rewards):
+        cnp.ndarray[float, ndim=1] episode_rewards):
 
         self._observations_np = observations
         self._observations = observations
@@ -217,10 +224,8 @@ cdef class GridEnv:
         self._terminals = terminals
         self._truncations_np = truncations
         self._truncations = truncations
-        self._rewards_np = rewards
-        self._rewards = rewards
-        self._episode_rewards_np = np.zeros_like(rewards)
-        self._episode_rewards = self._episode_rewards_np
+        self._episode_rewards_np = episode_rewards
+        self._episode_rewards = episode_rewards
 
         for i in range(self._agents.size()):
             self._agents[i].init(&self._rewards[i])
@@ -278,9 +283,6 @@ cdef class GridEnv:
         return {
             "game": self._stats.stats(),
         }
-
-    cpdef tuple get_buffers(self):
-        return (self._observations_np, self._terminals_np, self._truncations_np, self._rewards_np)
 
     cpdef cnp.ndarray render_ascii(self):
         cdef GridObject *obj

--- a/mettagrid/grid_env.pyx
+++ b/mettagrid/grid_env.pyx
@@ -197,7 +197,7 @@ cdef class GridEnv:
         self._truncations[:] = 0
         self._episode_rewards[:] = 0
         self._observations[:, :, :, :] = 0
-        # Maybe not needed, but left over from when reward was on the grid.        
+        # Maybe not needed, but left over from when reward was on the grid.
         for agent in self._agents:
             agent.reward = 0
 


### PR DESCRIPTION
Refactored `ActionHandler` to use a direct pointer to `Grid` instead of the entire `GridEnv`.

This will let us convert actions out of cython without immediately converting GridEnv.

Tested by compiling.