### PR TITLE
fix: address comments on PR #95

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,5 +99,5 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           source venv/bin/activate
-          pytest tests/test_basic.py
+          pytest tests
           python tests/test_kinship.py

--- a/mettagrid/map/node.py
+++ b/mettagrid/map/node.py
@@ -42,7 +42,7 @@ class Node:
         area = Area(
             id=len(self._areas),
             grid=self.grid[y : y + height, x : x + width],
-            tags=tags if tags is not None else [],
+            tags=tags or [],
         )
         self._areas.append(area)
         return area

--- a/mettagrid/map/node.py
+++ b/mettagrid/map/node.py
@@ -69,9 +69,10 @@ class Node:
                                     break
                             if match:
                                 selected_areas.append(area)
+                    else:
+                        raise ValueError(f"Invalid 'tags' format in 'where' clause: expected list, got {type(tags)}")
                 else:
-                    # Handle the case where "where" doesn't have expected structure
-                    selected_areas = areas
+                    raise ValueError(f"Invalid 'where' structure: {where}")
         else:
             selected_areas = areas
 

--- a/mettagrid/map/scene.py
+++ b/mettagrid/map/scene.py
@@ -17,7 +17,7 @@ class TypedChild(TypedDict):
 # Base class for all map scenes.
 class Scene:
     def __init__(self, children: Optional[List[TypedChild]] = None):
-        self._children = children if children is not None else []
+        self._children = children or []
         pass
 
     def make_node(self, grid: npt.NDArray[np.str_]):

--- a/mettagrid/map/scenes/random.py
+++ b/mettagrid/map/scenes/random.py
@@ -25,7 +25,7 @@ class Random(Scene):
     ):
         super().__init__()
         self._rng = np.random.default_rng(seed)
-        self._objects = objects if objects is not None else {}
+        self._objects = objects or {}
         self._agents = agents
         self._too_many_is_ok = too_many_is_ok
 

--- a/mettagrid/map/scenes/random_objects.py
+++ b/mettagrid/map/scenes/random_objects.py
@@ -25,7 +25,7 @@ class RandomObjects(Scene):
     ):
         super().__init__()
         self._rng = np.random.default_rng(seed)
-        self._object_ranges = object_ranges if object_ranges is not None else {}
+        self._object_ranges = object_ranges or {}
 
     def get_children(self, node: Node) -> list[TypedChild]:
         size = node.height * node.width


### PR DESCRIPTION
PR #95 was merged a bit early before all comments were addressed

### **Code Style**
- [x] Replace explicit `x if x is not None else []` with more concise `x or []` where safe and appropriate.
  - Example:  
    ```python
    self._children = children if children is not None else []
    ```
    becomes:
    ```python
    self._children = children or []
    ```
  - Location: `mettagrid/map/scene.py` and any similar patterns in other files

### **CI Workflow**
- [x] Update test runner in `.github/workflows/build.yml`:
  - Replace:
    ```bash
    pytest tests/test_basic.py
    ```
  - With:
    ```bash
    pytest tests
    ```
  - Rationale: Ensure all tests (e.g., `tests/test_pattern.py`) are included

### **Logic/Robustness**
- [x] In `mettagrid/map/node.py`, consider raising an error (or logging) when `where` does not match expected structure.
  - Current fallback:  
    ```python
    selected_areas = areas
    ```
  - Reviewer suggestion: `raise` may be more appropriate in some contexts

