### PR TITLE
Fix a test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -48,7 +48,7 @@ def test_dependencies():
     mettagrid_modules = [
         "mettagrid.objects",
         "mettagrid.observation_encoder",
-        "mettagrid.actions.actions",
+        "mettagrid.actions.metta_action_handler",
         "mettagrid.actions.attack",
         "mettagrid.actions.move",
         "mettagrid.actions.noop",


### PR DESCRIPTION
I broke test_basic's import tests. This passed locally because of left over compiled modules. I can't tell if it failed on github when I would have expected it to -- it's possible it didn't but in a non-blocking manner, and graphite ignored the non-blocking failure.

Anyway, just doing the basic fix for now.