### PR TITLE
fix: repair sampling resolver

### DIFF
--- a/mettagrid/resolvers.py
+++ b/mettagrid/resolvers.py
@@ -1,5 +1,5 @@
 import random
-from typing import Any, Dict, Optional, TypeVar, Union
+from typing import Any, Dict, TypeVar, Union
 
 import numpy as np
 from omegaconf import OmegaConf
@@ -63,9 +63,7 @@ def oc_equals(a: Any, b: Any) -> bool:
     return a == b
 
 
-def oc_scaled_range(
-    lower_limit: Numeric, upper_limit: Numeric, center: Numeric, *, root: Optional[Dict[str, Numeric]] = None
-) -> Numeric:
+def oc_scaled_range(lower_limit: Numeric, upper_limit: Numeric, center: Numeric, *, _root_: Dict[str, Any]) -> Numeric:
     """
     Generates a value centered around a specified point based on a "sampling" parameter that controls how
     widely the distribution spreads between the limiting values.
@@ -78,8 +76,9 @@ def oc_scaled_range(
         The maximum allowed value (upper boundary).
     center : Numeric
         The center point of the distribution. When sampling=0, this value is returned directly.
-    root : dict, optional
+    _root_ : dict (a named argument provided by OmegaConf)
         A dictionary containing the "sampling" parameter. If None, sampling defaults to 0. Must be between 0 and 1.
+        IMPORTANT: this parameter must be named "_root_" exactly as shown here.
 
     Returns:
     --------
@@ -87,9 +86,10 @@ def oc_scaled_range(
         A value between lower_limit and upper_limit, with distribution controlled by the sampling parameter.
         Returns integer if center is an integer, float otherwise.
     """
+
     # Get sampling parameter from root, defaulting to 0
-    root = root or {}
-    sampling = root.get("sampling", 0)
+    _root_ = _root_ or {}
+    sampling = _root_.get("sampling", 0)
 
     # Fast path: return center when sampling is 0
     if sampling == 0:

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -2,6 +2,8 @@
 Tests for the resolver module
 """
 
+from typing import Any, Dict, Union, cast
+
 import numpy as np
 import pytest
 from omegaconf import OmegaConf
@@ -23,122 +25,12 @@ from mettagrid.resolvers import (
 )
 
 
-def test_if_resolver():
-    """Test the if resolver functionality"""
-    assert oc_if(True, "yes", "no") == "yes"
-    assert oc_if(False, "yes", "no") == "no"
-
-
-def test_uniform_resolver():
-    """Test the uniform resolver generates values within range"""
-    # Run multiple times to ensure range is respected
-    for _ in range(100):
-        val = oc_uniform(10, 20)
-        assert 10 <= val <= 20
-
-
-def test_choose_resolver():
-    """Test the choose resolver picks from provided options"""
-    choices = [1, 2, 3]
-    # Run multiple times to ensure it's working
-    results = [oc_choose(*choices) for _ in range(100)]
-    # Check that we get all possible choices
-    assert all(r in choices for r in results)
-    # Check that we get some variety (this could theoretically fail but is very unlikely)
-    assert len(set(results)) > 1
-
-
-def test_arithmetic_resolvers():
-    """Test basic arithmetic resolvers"""
-    assert oc_add(3, 4) == 7
-    assert oc_subtract(10, 3) == 7
-    assert oc_multiply(3, 4) == 12
-    assert oc_divide(12, 4) == 3
-
-
-def test_equals_resolver():
-    """Test equals resolver comparison"""
-    assert oc_equals(5, 5) is True
-    assert oc_equals(5, "5") is False
-    assert oc_equals("abc", "abc") is True
-
-
-def test_clamp_resolver():
-    """Test clamp resolver bounds checking"""
-    assert oc_clamp(15, 10, 20) == 15  # Within range
-    assert oc_clamp(5, 10, 20) == 10  # Below min
-    assert oc_clamp(25, 10, 20) == 20  # Above max
-
-
-def test_make_integer_resolver():
-    """Test integer conversion resolver"""
-    assert oc_make_integer(3.2) == 3
-    assert oc_make_integer(3.7) == 4
-    assert oc_make_integer(3.5) == 4  # Rounds up at .5
-
-
-def test_to_odd_min3_resolver():
-    """Test conversion to odd number with minimum 3"""
-    assert oc_to_odd_min3(4) == 5  # Even becomes next odd
-    assert oc_to_odd_min3(5) == 5  # Odd stays the same
-    assert oc_to_odd_min3(1) == 3  # Below 3 becomes 3
-    assert oc_to_odd_min3(2) == 3  # Below 3 becomes 3
-    assert oc_to_odd_min3(0) == 3  # Zero becomes 3
-
-
-class TestScaledRange:
-    """Tests for the sampling (scaled range) resolver"""
-
-    def test_deterministic_mode(self):
-        """When sampling is 0, should return exactly the center value"""
-        root = {"sampling": 0}
-        # Integer case
-        assert oc_scaled_range(1, 100, 50, root=root) == 50
-        # Float case
-        assert oc_scaled_range(1.0, 100.0, 50.5, root=root) == 50.5
-
-    def test_full_range(self):
-        """When sampling is 1, should use the full range"""
-        np.random.seed(42)  # For reproducibility
-        root = {"sampling": 1.0}
-
-        # Run multiple times and check that values fall in correct range
-        values = [oc_scaled_range(1, 100, 50, root=root) for _ in range(100)]
-        # Should be integers due to center being an integer
-        assert all(isinstance(v, int) for v in values)
-        # Should be within the full range
-        assert all(1 <= v <= 100 for v in values)
-
-        # Similar test for float center
-        float_values = [oc_scaled_range(1.0, 100.0, 50.5, root=root) for _ in range(100)]
-        # Should be floats due to center being a float
-        assert all(isinstance(v, float) for v in float_values)
-        # Should be within the full range
-        assert all(1.0 <= v <= 100.0 for v in float_values)
-
-    def test_partial_range(self):
-        """When sampling is between 0 and 1, should use partial range"""
-        np.random.seed(42)  # For reproducibility
-        root = {"sampling": 0.5}
-
-        # With sampling=0.5, values should be in range [center-0.5*left, center+0.5*right]
-        # For range [1, 100] with center 50, this means [25.5, 74.5]
-        values = [oc_scaled_range(1, 100, 50, root=root) for _ in range(100)]
-        assert all(25 <= v <= 75 for v in values)
-
-    def test_sampling_validation(self):
-        """Should raise an assertion error if sampling > 1"""
-        root = {"sampling": 1.1}
-        with pytest.raises(AssertionError):
-            oc_scaled_range(1, 100, 50, root=root)
-
-
-def test_resolver_registration():
-    """Test that resolvers are properly registered with OmegaConf"""
-    # Register resolvers directly in this test
+# Fixtures
+@pytest.fixture
+def omega_conf_with_resolvers():
+    """Fixture providing an OmegaConf with resolvers registered"""
     register_resolvers()
-
-    conf = OmegaConf.create(
+    return OmegaConf.create(
         {
             "add_result": "${add:2,3}",
             "sub_result": "${sub:10,5}",
@@ -147,24 +39,12 @@ def test_resolver_registration():
         }
     )
 
-    # Explicitly resolve all interpolations
-    OmegaConf.resolve(conf)
 
-    assert OmegaConf.to_container(conf) == {
-        "add_result": 5,
-        "sub_result": 5,
-        "if_result": "yes",
-        "eq_result": True,
-    }
-
-
-def test_sampling_resolver_in_config():
-    """Test the sampling resolver in a configuration scenario"""
-    # Register resolvers directly in this test
+@pytest.fixture
+def omega_conf_with_sampling():
+    """Fixture providing an OmegaConf with sampling parameter"""
     register_resolvers()
-
-    # Create a config with the sampling parameter
-    conf = OmegaConf.create(
+    return OmegaConf.create(
         {
             "sampling": 0,  # Deterministic mode
             "param1": "${sampling:1,100,50}",
@@ -172,20 +52,300 @@ def test_sampling_resolver_in_config():
         }
     )
 
-    # Explicitly resolve all interpolations
-    OmegaConf.resolve(conf)
 
-    # In deterministic mode, should get exact center values
-    assert OmegaConf.to_container(conf) == {
-        "sampling": 0,
-        "param1": 50,
-        "param2": 25,
-    }
+class TestBasicResolvers:
+    """Tests for basic resolver functionality"""
 
-    # Change to random mode
-    conf.sampling = 1.0
-    resolved = OmegaConf.to_container(conf)
+    @pytest.mark.parametrize(
+        "condition,true_value,false_value,expected",
+        [
+            (True, "yes", "no", "yes"),
+            (False, "yes", "no", "no"),
+            (True, 10, 20, 10),
+            (False, 10, 20, 20),
+        ],
+    )
+    def test_if_resolver(self, condition, true_value, false_value, expected):
+        """Test the if resolver with various inputs"""
+        assert oc_if(condition, true_value, false_value) == expected
 
-    # Values should now be randomized, but within range
-    assert 1 <= resolved["param1"] <= 100
-    assert 1 <= resolved["param2"] <= 100
+    def test_uniform_resolver(self):
+        """Test the uniform resolver generates values within range"""
+        # Set seed for reproducibility
+        np.random.seed(42)
+
+        # Test multiple ranges
+        ranges = [(10, 20), (0, 1), (-10, 10)]
+        for min_val, max_val in ranges:
+            for _ in range(20):  # Run multiple times to ensure range is respected
+                val = oc_uniform(min_val, max_val)
+                assert min_val <= val <= max_val
+
+    def test_choose_resolver(self):
+        """Test the choose resolver picks from provided options"""
+        # Set seed for reproducibility
+        np.random.seed(42)
+
+        test_cases = [
+            [1, 2, 3],
+            ["apple", "banana", "cherry"],
+            [True, False],
+        ]
+
+        for choices in test_cases:
+            # Run multiple times to ensure it's working
+            results = [oc_choose(*choices) for _ in range(30)]
+            # Check that we get all possible choices
+            assert all(r in choices for r in results)
+            # Check that we get some variety (this could theoretically fail but is very unlikely)
+            assert len(set(results)) > 1
+
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            (3, 4, 7),  # Positive integers
+            (-3, 4, 1),  # Mixed signs
+            (3.5, 4.5, 8.0),  # Floating point
+        ],
+    )
+    def test_add_resolver(self, a, b, expected):
+        """Test addition resolver with various inputs"""
+        assert oc_add(a, b) == expected
+
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            (10, 3, 7),  # Positive integers
+            (3, 10, -7),  # Result negative
+            (10.5, 3.5, 7.0),  # Floating point
+        ],
+    )
+    def test_subtract_resolver(self, a, b, expected):
+        """Test subtraction resolver with various inputs"""
+        assert oc_subtract(a, b) == expected
+
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            (3, 4, 12),  # Positive integers
+            (-3, 4, -12),  # Mixed signs
+            (3.5, 2, 7.0),  # Floating point
+        ],
+    )
+    def test_multiply_resolver(self, a, b, expected):
+        """Test multiplication resolver with various inputs"""
+        assert oc_multiply(a, b) == expected
+
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            (12, 4, 3),  # Positive integers, exact division
+            (12, 5, 2.4),  # Positive integers, floating point result
+            (-12, 4, -3),  # Mixed signs
+        ],
+    )
+    def test_divide_resolver(self, a, b, expected):
+        """Test division resolver with various inputs"""
+        assert oc_divide(a, b) == expected
+
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            (5, 5, True),  # Same integers
+            (5, "5", False),  # Different types
+            ("abc", "abc", True),  # Same strings
+            ("abc", "ABC", False),  # Case-sensitive comparison
+            (True, True, True),  # Booleans
+            ([], [], True),  # Empty collections
+        ],
+    )
+    def test_equals_resolver(self, a, b, expected):
+        """Test equals resolver with various inputs"""
+        assert oc_equals(a, b) is expected
+
+    @pytest.mark.parametrize(
+        "value,min_val,max_val,expected",
+        [
+            (15, 10, 20, 15),  # Within range
+            (5, 10, 20, 10),  # Below min
+            (25, 10, 20, 20),  # Above max
+            (10, 10, 20, 10),  # At min boundary
+            (20, 10, 20, 20),  # At max boundary
+        ],
+    )
+    def test_clamp_resolver(self, value, min_val, max_val, expected):
+        """Test clamp resolver with various inputs"""
+        assert oc_clamp(value, min_val, max_val) == expected
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (3.2, 3),  # Round down
+            (3.5, 4),  # Round up at .5
+            (3.7, 4),  # Round up
+            (0.1, 0),  # Near zero, round down
+            (-1.7, -2),  # Negative, round down
+            (-1.2, -1),  # Negative, round up
+        ],
+    )
+    def test_make_integer_resolver(self, value, expected):
+        """Test integer conversion resolver with various inputs"""
+        assert oc_make_integer(value) == expected
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (4, 5),  # Even becomes next odd
+            (5, 5),  # Odd stays the same
+            (1, 3),  # Below 3 becomes 3
+            (2, 3),  # Below 3 becomes 3
+            (0, 3),  # Zero becomes 3
+            (-1, 3),  # Negative becomes 3
+        ],
+    )
+    def test_to_odd_min3_resolver(self, value, expected):
+        """Test conversion to odd number with minimum 3 with various inputs"""
+        assert oc_to_odd_min3(value) == expected
+
+
+class TestScaledRange:
+    """Tests for the sampling (scaled range) resolver"""
+
+    @pytest.mark.parametrize(
+        "min_val,max_val,center,expected",
+        [
+            (1, 100, 50, 50),  # Integer center
+            (1.0, 100.0, 50.5, 50.5),  # Float center
+            (-10, 10, 0, 0),  # Zero center
+        ],
+    )
+    def test_deterministic_mode(self, min_val, max_val, center, expected):
+        """When sampling is 0, should return exactly the center value"""
+        root = cast(Dict[str, Union[int, float]], {"sampling": 0.0})
+        assert oc_scaled_range(min_val, max_val, center, _root_=root) == expected
+
+    def test_full_range(self):
+        """When sampling is 1, should use the full range"""
+        np.random.seed(42)  # For reproducibility
+        root = cast(Dict[str, Union[int, float]], {"sampling": 1.0})
+
+        # Test integer ranges
+        int_ranges = [(1, 100, 50), (-50, 50, 0), (1, 10, 5)]
+        for min_val, max_val, center in int_ranges:
+            values = [oc_scaled_range(min_val, max_val, center, _root_=root) for _ in range(30)]
+            # Should be integers due to center being an integer
+            assert all(isinstance(v, int) for v in values)
+            # Should be within the full range
+            assert all(min_val <= v <= max_val for v in values)
+            # Should have some variety
+            assert len(set(values)) > 1
+
+        # Test float ranges
+        float_ranges = [(1.0, 100.0, 50.5), (-10.0, 10.0, 0.5)]
+        for min_val, max_val, center in float_ranges:
+            values = [oc_scaled_range(min_val, max_val, center, _root_=root) for _ in range(30)]
+            # Should be floats due to center being a float
+            assert all(isinstance(v, float) for v in values)
+            # Should be within the full range
+            assert all(min_val <= v <= max_val for v in values)
+            # Should have some variety
+            assert len(set(values)) > 1
+
+    @pytest.mark.parametrize(
+        "sampling,min_val,max_val,center,expected_min,expected_max",
+        [
+            (0.5, 1, 100, 50, 25, 75),  # 50% range around center 50
+            (0.25, 0, 100, 50, 37, 63),  # 25% range around center 50
+            (0.75, -100, 100, 0, -75, 75),  # 75% range around center 0
+        ],
+    )
+    def test_partial_range(self, sampling, min_val, max_val, center, expected_min, expected_max):
+        """When sampling is between 0 and 1, should use partial range"""
+        np.random.seed(42)  # For reproducibility
+        root = {"sampling": sampling}
+
+        values = [oc_scaled_range(min_val, max_val, center, _root_=root) for _ in range(100)]
+        assert all(expected_min <= v <= expected_max for v in values)
+
+    def test_sampling_validation(self):
+        """Should raise an assertion error if sampling > 1"""
+        invalid_values = [1.1, 2.0, 100]
+        for invalid_value in invalid_values:
+            root = {"sampling": invalid_value}
+            with pytest.raises(AssertionError):
+                oc_scaled_range(1, 100, 50, _root_=root)
+
+
+class TestConfigIntegration:
+    """Tests for resolvers integrated with OmegaConf"""
+
+    def test_resolver_registration(self, omega_conf_with_resolvers):
+        """Test that resolvers are properly registered with OmegaConf"""
+        # Explicitly resolve all interpolations
+        OmegaConf.resolve(omega_conf_with_resolvers)
+
+        assert OmegaConf.to_container(omega_conf_with_resolvers) == {
+            "add_result": 5,
+            "sub_result": 5,
+            "if_result": "yes",
+            "eq_result": True,
+        }
+
+    def test_sampling_resolver_deterministic(self, omega_conf_with_sampling):
+        """Test the sampling resolver in deterministic mode"""
+        # Explicitly resolve all interpolations
+        OmegaConf.resolve(omega_conf_with_sampling)
+
+        # In deterministic mode, should get exact center values
+        assert OmegaConf.to_container(omega_conf_with_sampling) == {
+            "sampling": 0,
+            "param1": 50,
+            "param2": 25,
+        }
+
+    def test_sampling_resolver_random(self, omega_conf_with_sampling):
+        """Test the sampling resolver in random mode"""
+
+        print(f"On entry - {omega_conf_with_sampling}")
+
+        # Change to random mode and set seed
+        np.random.seed(42)
+
+        # Update sampling and re-create the interpolated fields
+        omega_conf_with_sampling.sampling = 1.0
+        omega_conf_with_sampling.param1 = "${sampling:1,100,50}"
+        omega_conf_with_sampling.param2 = "${sampling:1,100,25}"
+
+        print(f"after overwrite - {omega_conf_with_sampling}")
+
+        # Resolve and check
+        OmegaConf.resolve(omega_conf_with_sampling)
+
+        print(f"after resolve - {omega_conf_with_sampling}")
+
+        resolved = OmegaConf.to_container(omega_conf_with_sampling)
+
+        # Make sure resolved is not None
+        assert resolved is not None, "OmegaConf.to_container returned None"
+
+        # Type hinting to help the type checker
+        from typing import Dict, cast
+
+        resolved_dict = cast(Dict[str, Any], resolved)
+
+        print(f"resolved_dict - {resolved_dict}")
+
+        # Values should now be randomized, but within range
+        param1 = resolved_dict.get("param1")
+        param2 = resolved_dict.get("param2")
+
+        # Check that the parameters exist
+        assert param1 is not None, "param1 not found in resolved config"
+        assert param2 is not None, "param2 not found in resolved config"
+
+        # Now perform the range checks with explicit type conversion
+        assert 1 <= float(param1) <= 100
+        assert 1 <= float(param2) <= 100
+
+        # Different from center values
+        assert float(param1) != 50.0 or float(param2) != 25.0


### PR DESCRIPTION
## Problem
The resolver function `sampling` was always returning deterministic center values due to improper parameter handling. The named parameter from hydra has underscores (`_root_`) which were mistakenly treated as formatting by LLM-generated code or documentation.

## Changes
- Fixed parameter naming in the `oc_scaled_range` function
- Removed the optional typing for the root parameter
- Corrected the documentation to properly describe the `root` parameter
- Ensured consistent handling of the root dictionary